### PR TITLE
Fixed golangci-lint errors

### DIFF
--- a/cmd/witness/impl/witness.go
+++ b/cmd/witness/impl/witness.go
@@ -23,14 +23,14 @@ import (
 	"net/http"
 
 	"github.com/golang/glog"
-	i_note "github.com/transparency-dev/witness/internal/note"
-	ih "github.com/transparency-dev/witness/internal/http"
-	wsql "github.com/transparency-dev/witness/internal/persistence/sql"
-	"github.com/transparency-dev/witness/internal/witness"
 	"github.com/gorilla/mux"
 	_ "github.com/mattn/go-sqlite3" // Load drivers for sqlite3
 	logfmt "github.com/transparency-dev/formats/log"
 	"github.com/transparency-dev/merkle/rfc6962"
+	ih "github.com/transparency-dev/witness/internal/http"
+	i_note "github.com/transparency-dev/witness/internal/note"
+	wsql "github.com/transparency-dev/witness/internal/persistence/sql"
+	"github.com/transparency-dev/witness/internal/witness"
 	"golang.org/x/mod/sumdb/note"
 )
 
@@ -138,6 +138,8 @@ func Main(ctx context.Context, opts ServerOpts) error {
 	}()
 	<-ctx.Done()
 	glog.Info("Server shutting down")
-	hServer.Shutdown(ctx)
+	if err := hServer.Shutdown(ctx); err != nil {
+		return fmt.Errorf("failed to shutdown server: %v", err)
+	}
 	return <-e
 }

--- a/internal/feeder/sumdb/sumdb_feeder.go
+++ b/internal/feeder/sumdb/sumdb_feeder.go
@@ -152,7 +152,9 @@ func (t tile) hash(n compact.NodeID) []byte {
 		panic(fmt.Sprintf("index %d out of range of %d leaves", right, len(t.leaves)))
 	}
 	for _, l := range t.leaves[left:right] {
-		r.Append(l[:], nil)
+		if err := r.Append(l[:], nil); err != nil {
+			panic(fmt.Sprintf("couldn't append leaf: %v", err))
+		}
 	}
 	root, err := r.GetRootHash(nil)
 	if err != nil {

--- a/internal/feeder/sumdb/sumdb_feeder_test.go
+++ b/internal/feeder/sumdb/sumdb_feeder_test.go
@@ -143,7 +143,9 @@ func TestTileBroker(t *testing.T) {
 			if got, want := len(tile.leaves), test.wantLeaves; got != want {
 				t.Errorf("got %d leaves, wanted %d", got, want)
 			}
-			broker.tile(test.i)
+			if _, err := broker.tile(test.i); err != nil {
+				t.Fatalf("failed to get tile: %v", err)
+			}
 			if lookupTimes != 1 {
 				t.Errorf("broker cache not working")
 			}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -21,9 +21,10 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/golang/glog"
+	"github.com/gorilla/mux"
 	"github.com/transparency-dev/witness/api"
 	"github.com/transparency-dev/witness/internal/witness"
-	"github.com/gorilla/mux"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -73,7 +74,9 @@ func (s *Server) update(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	w.Header().Set("Content-Type", "text/plain")
-	w.Write(chkpt)
+	if _, err := w.Write(chkpt); err != nil {
+		glog.Warningf("Error writing response: %v", err)
+	}
 }
 
 // getCheckpoint returns a checkpoint stored for a given log.
@@ -87,7 +90,9 @@ func (s *Server) getCheckpoint(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/plain")
-	w.Write(chkpt)
+	if _, err := w.Write(chkpt); err != nil {
+		glog.Warningf("Error writing response: %v", err)
+	}
 }
 
 // getLogs returns a list of all logs the witness is aware of.
@@ -103,7 +108,9 @@ func (s *Server) getLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/json")
-	w.Write(logList)
+	if _, err := w.Write(logList); err != nil {
+		glog.Warningf("Error writing response: %v", err)
+	}
 }
 
 // RegisterHandlers registers HTTP handlers for witness endpoints.

--- a/internal/persistence/inmemory/inmemory.go
+++ b/internal/persistence/inmemory/inmemory.go
@@ -131,5 +131,6 @@ func (rw *readWriter) Set(c []byte, rng []byte) error {
 	return rw.write(rw.read, *rw.toStore)
 }
 
-func (rw *readWriter) Close() {
+func (rw *readWriter) Close() error {
+	return nil
 }

--- a/internal/persistence/inmemory/inmemory_test.go
+++ b/internal/persistence/inmemory/inmemory_test.go
@@ -19,9 +19,9 @@ import (
 	"strings"
 	"testing"
 
+	_ "github.com/mattn/go-sqlite3" // Load drivers for sqlite3
 	"github.com/transparency-dev/witness/internal/persistence"
 	ptest "github.com/transparency-dev/witness/internal/persistence/testonly"
-	_ "github.com/mattn/go-sqlite3" // Load drivers for sqlite3
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -60,7 +60,7 @@ func TestWriteOpsConcurrent(t *testing.T) {
 				}
 			}
 			// Ignore any error on Set because we expect some.
-			w.Set([]byte(fmt.Sprintf("success %d", i)), nil)
+			_ = w.Set([]byte(fmt.Sprintf("success %d", i)), nil)
 			return nil
 		})
 	}

--- a/internal/persistence/inmemory/inmemory_test.go
+++ b/internal/persistence/inmemory/inmemory_test.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3" // Load drivers for sqlite3
 	"github.com/transparency-dev/witness/internal/persistence"
 	ptest "github.com/transparency-dev/witness/internal/persistence/testonly"
 	"golang.org/x/sync/errgroup"

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -62,5 +62,5 @@ type LogStateWriteOps interface {
 
 	// Terminates the write operation, freeing all resources.
 	// This method MUST be called.
-	Close()
+	Close() error
 }

--- a/internal/persistence/sql/sql.go
+++ b/internal/persistence/sql/sql.go
@@ -110,8 +110,8 @@ func (w *writer) Set(c []byte, rng []byte) error {
 	return w.tx.Commit()
 }
 
-func (w *writer) Close() {
-	w.tx.Rollback()
+func (w *writer) Close() error {
+	return w.tx.Rollback()
 }
 
 func getLatestCheckpoint(queryRow func(query string, args ...interface{}) *sql.Row, logID string) ([]byte, []byte, error) {

--- a/internal/persistence/testonly/persistence.go
+++ b/internal/persistence/testonly/persistence.go
@@ -28,7 +28,11 @@ import (
 // TestGetLogs exposes a test that can be invoked by tests for specific implementations of persistence.
 func TestGetLogs(t *testing.T, lspFactory func() (persistence.LogStatePersistence, func() error)) {
 	lsp, close := lspFactory()
-	defer close()
+	defer func() {
+		if err := close(); err != nil {
+			t.Fatalf("close(): %v", err)
+		}
+	}()
 	if err := lsp.Init(); err != nil {
 		t.Fatalf("Init(): %v", err)
 	}
@@ -52,7 +56,11 @@ func TestGetLogs(t *testing.T, lspFactory func() (persistence.LogStatePersistenc
 // TestWriteOps exposes a test that can be invoked by tests for specific implementations of persistence.
 func TestWriteOps(t *testing.T, lspFactory func() (persistence.LogStatePersistence, func() error)) {
 	lsp, close := lspFactory()
-	defer close()
+	defer func() {
+		if err := close(); err != nil {
+			t.Fatalf("close(): %v", err)
+		}
+	}()
 	if err := lsp.Init(); err != nil {
 		t.Fatalf("Init(): %v", err)
 	}

--- a/internal/witness/witness.go
+++ b/internal/witness/witness.go
@@ -23,11 +23,11 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/transparency-dev/witness/internal/persistence"
 	"github.com/transparency-dev/formats/log"
 	"github.com/transparency-dev/merkle"
 	"github.com/transparency-dev/merkle/compact"
 	"github.com/transparency-dev/merkle/proof"
+	"github.com/transparency-dev/witness/internal/persistence"
 	"golang.org/x/mod/sumdb/note"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -246,7 +246,9 @@ func verifyRange(next *log.Checkpoint, prev *log.Checkpoint, h merkle.LogHasher,
 		return nil, fmt.Errorf("can't form delta compact range: %v", err)
 	}
 	// Merge the delta range into the existing one and compare root hashes.
-	rng.AppendRange(delta, nil)
+	if err := rng.AppendRange(delta, nil); err != nil {
+		return nil, fmt.Errorf("failed to append range: %v", err)
+	}
 	if err := verifyRangeHash(next.Hash, rng); err != nil {
 		return nil, fmt.Errorf("new root hash doesn't verify: %v", err)
 	}


### PR DESCRIPTION
This may change behaviour in some situations, but almost certainly for
the better. Previously errors during finalizing operations were dropped,
and there would be no trace in the local logs if HTTP responses could
not be written.
