### PR TITLE
Dockerfiles now refer to the correct paths

### DIFF
--- a/cmd/omniwitness/Dockerfile
+++ b/cmd/omniwitness/Dockerfile
@@ -17,7 +17,7 @@ RUN go mod download
 COPY . .
 
 # Build the application
-RUN go build -o omniwitness ./witness/golang/cmd/omniwitness
+RUN go build -o omniwitness ./cmd/omniwitness
 
 # Build release image
 FROM alpine

--- a/cmd/witness/Dockerfile
+++ b/cmd/witness/Dockerfile
@@ -16,7 +16,7 @@ RUN go mod download
 COPY . .
 
 # Build the application
-RUN go build -o /build/bin/witness ./witness/golang/cmd/witness
+RUN go build -o /build/bin/witness ./cmd/witness
 
 # Build release image
 FROM alpine


### PR DESCRIPTION
They were referring to the old locations in trillian-examples
