### PR TITLE
Added cloudbuild docker config for trillian-opensource-ci

### DIFF
--- a/cloudbuild_docker_legacy.yaml
+++ b/cloudbuild_docker_legacy.yaml
@@ -32,8 +32,8 @@ steps:
       'buildx',
       'build',
       '--platform', '$_DOCKER_BUILDX_PLATFORMS',
-      '-t', 'us-docker.pkg.dev/transparency-dev/docker/omniwitness:latest',
-      '--cache-from', 'us-docker.pkg.dev/transparency-dev/docker/omniwitness:latest',
+      '-t', 'gcr.io/trillian-opensource-ci/omniwitness:latest',
+      '--cache-from', 'gcr.io/trillian-opensource-ci/omniwitness:latest',
       '-f', './cmd/omniwitness/Dockerfile',
       '--push',
       '.'


### PR DESCRIPTION
This is forked from the non-legacy version of the config. This is a short-term solution to build public docker images until we are able to complete the internal process to allow the transparency-dev project to expose artifacts to the public.

It's a bit naughty, but I also snuck in a small amount of tidy-up in
both files to delete a variable that wasn't used.
