### PR TITLE
Revert "Bump linuxkit/binfmt from 0.8 to 1.0.1"

### DIFF
--- a/cloudbuild_docker_legacy.yaml
+++ b/cloudbuild_docker_legacy.yaml
@@ -15,7 +15,7 @@ options:
 
 steps:
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['run', '--privileged', 'linuxkit/binfmt:v1.0.1']
+    args: ['run', '--privileged', 'linuxkit/binfmt:v0.8']
     id: 'initialize-qemu'
   - name: 'gcr.io/cloud-builders/docker'
     args: ['buildx', 'create', '--name', 'mybuilder']


### PR DESCRIPTION
Reverts transparency-dev/witness#33. While the underlying library has newer tags, these are not available in docker yet: https://hub.docker.com/r/linuxkit/binfmt/tags

Rolling back first. TODO is investigate whether any of the new tagged images correspond to one of the tagged releases in guthub.