### PR TITLE
Update and rename scorecards.yml to scorecard.yml

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -2,7 +2,7 @@
 # by a third-party and are governed by separate terms of service, privacy
 # policy, and support documentation.
 
-name: Scorecards supply-chain security
+name: Scorecard supply-chain security
 on:
   # For Branch-Protection check. Only the default branch is supported. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
@@ -19,7 +19,7 @@ permissions: read-all
 
 jobs:
   analysis:
-    name: Scorecards analysis
+    name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard.


### PR DESCRIPTION
Update descriptions in the file to match too.

Given this file was autogenerated and the current autogeneration tool now uses "scorecard" for the name and in descriptions, it looks like the naming subtly shifted at some point.

This PR brings it back into line FWIW.