### PR TITLE
Fix the docker build

### DIFF
--- a/cmd/omniwitness/Dockerfile
+++ b/cmd/omniwitness/Dockerfile
@@ -17,10 +17,10 @@ RUN go mod download
 COPY . .
 
 # Build the application
-RUN go build -o omniwitness ./cmd/omniwitness
+RUN go build -o bin/omniwitness ./cmd/omniwitness
 
 # Build release image
 FROM alpine
 
-COPY --from=builder /build/omniwitness /bin/omniwitness
+COPY --from=builder /build/bin/omniwitness /bin/omniwitness
 ENTRYPOINT ["/bin/omniwitness"]


### PR DESCRIPTION
There was a name collision between the desired output bin file and a directory in the root of this repo called omniwitness. This change builds into /bin/omniwitness in order to avoid that collision.
