### PR TITLE
Update link in docker-compose to freshest image

### DIFF
--- a/cmd/omniwitness/docker-compose.yaml
+++ b/cmd/omniwitness/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.2'
 services:
   witness:
-    image: gcr.io/trillian-opensource-ci/omniwitness-monolith:${WITNESS_VERSION}
+    image: gcr.io/trillian-opensource-ci/omniwitness:${WITNESS_VERSION}
     volumes:
         - type: volume
           source: data


### PR DESCRIPTION
The previous image is a stale one that was built from trillian-examples, where the new image is the one built from the latest version of the code in this repo.
