### PR TITLE
Update Pixel BT log origin

### DIFF
--- a/omniwitness/logs.yaml
+++ b/omniwitness/logs.yaml
@@ -21,7 +21,7 @@ Logs:
     PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
     Feeder: rekor
     UseCompact: false
-  - Origin: DEFAULT
+  - Origin: developers.google.com/android/binary_transparency/0
     URL: https://developers.google.com/android/binary_transparency/
     PublicKeyType: ecdsa
     PublicKey: pixel_transparency_log+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=


### PR DESCRIPTION
This updates the Pixel BT log origin string from `DEFAULT` to the one now being served by the log.