### PR TITLE
Update Rekor feeder to get stable checkpoint

### DIFF
--- a/internal/feeder/rekor/rekor_feeder.go
+++ b/internal/feeder/rekor/rekor_feeder.go
@@ -86,7 +86,7 @@ func FeedLog(ctx context.Context, l config.Log, w feeder.Witness, c *http.Client
 		// Each Rekor feeder will request the same log info.
 		// TODO: Explore if it's feasible to request this once for all Rekor feeders.
 		li := logInfo{}
-		if err := getJSON(ctx, c, lURL, "api/v1/log", &li); err != nil {
+		if err := getJSON(ctx, c, lURL, "api/v1/log?stable=true", &li); err != nil {
 			return nil, fmt.Errorf("failed to fetch log info: %v", err)
 		}
 		// Active shard


### PR DESCRIPTION
Rekor can now optionally return a stable checkpoint that updates every 5 minutes rather than each time a new entry is uploaded. This lets the distributor gather matching cosigned checkpoints from witnesses.