### PR TITLE
Dependabot for docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,17 @@
 version: 2
 updates:
 - package-ecosystem: gomod
-  directory: "/"
+  directory: /
+  schedule:
+    interval: daily
+
+- package-ecosystem: github-actions
+  directory: /
   schedule:
     interval: weekly
-  open-pull-requests-limit: 10
-- package-ecosystem: "github-actions"
-  directory: "/"
+
+- package-ecosystem: docker
+  directory: /cmd/omniwitness
   schedule:
-    interval: "weekly"
+    interval: daily
+

--- a/cmd/omniwitness/Dockerfile
+++ b/cmd/omniwitness/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS builder
+FROM golang:1.19-alpine@sha256:c5e8766b6a7b77fd60a48c2b932f7ea66f7001489c4cf18d0265cff595613bee AS builder
 RUN apk add --no-cache gcc musl-dev
 
 ARG GOFLAGS=""
@@ -20,7 +20,7 @@ COPY . .
 RUN go build -o bin/omniwitness ./cmd/omniwitness
 
 # Build release image
-FROM alpine
+FROM alpine:3.17.3@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126
 
 COPY --from=builder /build/bin/omniwitness /bin/omniwitness
 ENTRYPOINT ["/bin/omniwitness"]


### PR DESCRIPTION
Update docker images using dependabot, and pin to hashes to make sure everyone uses the same base image
