### PR TITLE
Follow serverless-log move

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,9 +20,9 @@ require (
 )
 
 require (
-	github.com/google/trillian-examples v0.0.0-20230419170052-1d4b6bbacc57
 	github.com/prometheus/client_golang v1.16.0
-	github.com/transparency-dev/formats v0.0.0-20230607101544-c064fae4cff6
+	github.com/transparency-dev/formats v0.0.0-20230914071414-5732692f1e50
+	github.com/transparency-dev/serverless-log v0.0.0-20230914155322-9b6f31f76f1f
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,6 @@ github.com/google/go-github/v39 v39.2.0 h1:rNNM311XtPOz5rDdsJXAp2o8F67X9FnROXTvt
 github.com/google/go-github/v39 v39.2.0/go.mod h1:C1s8C5aCC9L+JXIYpJM5GYytdX52vC1bLvHEF1IhBrE=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
-github.com/google/trillian-examples v0.0.0-20230419170052-1d4b6bbacc57 h1:zSMxiN70oz/O4HMBr+Iu8hrNAvXSzG9q5cML1jKk00E=
-github.com/google/trillian-examples v0.0.0-20230419170052-1d4b6bbacc57/go.mod h1:dJrNRA0spf31+GXhcQ/kDn3W7TwDt6Niv7ZvIm/vji8=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -45,10 +43,12 @@ github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+Pymzi
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/transparency-dev/formats v0.0.0-20230607101544-c064fae4cff6 h1:Mjc7czQhATVAWBRZecClSQlWFMiW/42AZdYzp4qRnqQ=
-github.com/transparency-dev/formats v0.0.0-20230607101544-c064fae4cff6/go.mod h1:Nb+V5XS9fhtScBd8Zb7BmCywNSu1eGQvJqGXodST9cw=
+github.com/transparency-dev/formats v0.0.0-20230914071414-5732692f1e50 h1:FVMl+jA2NBlbUm5XjLJNMrSLqbA/SpeXhKoirj3MMwg=
+github.com/transparency-dev/formats v0.0.0-20230914071414-5732692f1e50/go.mod h1:J2NdDb6IhKIvF6MwCvKikz9/QStRylEtS2mv+En+jBg=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
+github.com/transparency-dev/serverless-log v0.0.0-20230914155322-9b6f31f76f1f h1:quFhOfslKXkqvTCN0s5o2G/i/DLpfKkHFL893MnLetU=
+github.com/transparency-dev/serverless-log v0.0.0-20230914155322-9b6f31f76f1f/go.mod h1:wePHXib4JC193IyIQImP3oNXYpUZQWzKcF6BJ8bC8GY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.13.0 h1:mvySKfSWJ+UKUii46M40LOvyWfN0s2U+46/jDd0e6Ck=

--- a/internal/feeder/feeder_test.go
+++ b/internal/feeder/feeder_test.go
@@ -21,10 +21,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/trillian-examples/serverless/client"
-	"github.com/google/trillian-examples/serverless/testdata"
 	"github.com/transparency-dev/formats/log"
 	"github.com/transparency-dev/merkle/rfc6962"
+	"github.com/transparency-dev/serverless-log/client"
+	"github.com/transparency-dev/serverless-log/testdata"
 	"golang.org/x/mod/sumdb/note"
 )
 

--- a/internal/feeder/serverless/serverless_feeder.go
+++ b/internal/feeder/serverless/serverless_feeder.go
@@ -24,9 +24,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/google/trillian-examples/serverless/client"
 	"github.com/transparency-dev/formats/log"
 	"github.com/transparency-dev/merkle/rfc6962"
+	"github.com/transparency-dev/serverless-log/client"
 	"github.com/transparency-dev/witness/internal/config"
 	"github.com/transparency-dev/witness/internal/feeder"
 )


### PR DESCRIPTION
This PR updates the witness repo to follow the [graduation of `serverless` to its own repo](https://github.com/transparency-dev/serverless-log).