### PR TITLE
Disable broken armv7 builds

### DIFF
--- a/cloudbuild_docker_legacy.yaml
+++ b/cloudbuild_docker_legacy.yaml
@@ -43,4 +43,4 @@ steps:
     id: 'build-omniwitness-image'
 
 substitutions:
-  _DOCKER_BUILDX_PLATFORMS: 'linux/amd64,linux/arm/v7'
+  _DOCKER_BUILDX_PLATFORMS: 'linux/amd64


### PR DESCRIPTION
Not a single build has succeeded in months, all due to timeouts. This is a known issue that seems unlikely to be fixed given the activity on https://github.com/docker/buildx/issues/350. For the time being, disable these builds so we at least get the amd64 builds.
