### PR TITLE
Fail on redirect changing request method

### DIFF
--- a/internal/distribute/rest/distribute.go
+++ b/internal/distribute/rest/distribute.go
@@ -128,6 +128,9 @@ func (d *Distributor) distributeForLog(ctx context.Context, l config.Log) error 
 	if err != nil {
 		return fmt.Errorf("failed to do http request: %v", err)
 	}
+	if resp.Request.Method != "PUT" {
+		return fmt.Errorf("PUT request to %q was converted to %s request to %q", u.String(), resp.Request.Method, resp.Request.URL)
+	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
A PUT request that hits a redirect gets converted to a GET request to the new resource. All of the existing checks for 200 will pass, which makes it look like it distributed even though no mutation operation occurred. This is a massive trap that is way too easy to fall into.
