### PR TITLE
Safeguard against redirects on PUT request

### DIFF
--- a/client/http/witness_client.go
+++ b/client/http/witness_client.go
@@ -93,6 +93,9 @@ func (w Witness) Update(ctx context.Context, logID string, cp []byte, proof [][]
 	if err != nil {
 		return nil, fmt.Errorf("failed to do http request: %v", err)
 	}
+	if resp.Request.Method != "PUT" {
+		return nil, fmt.Errorf("PUT request to %q was converted to %s request to %q", u.String(), resp.Request.Method, resp.Request.URL)
+	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/client/http/witness_client.go
+++ b/client/http/witness_client.go
@@ -53,7 +53,7 @@ func (w Witness) GetLatestCheckpoint(ctx context.Context, logID string) ([]byte,
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL: %v", err)
 	}
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
@@ -85,7 +85,7 @@ func (w Witness) Update(ctx context.Context, logID string, cp []byte, proof [][]
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL: %v", err)
 	}
-	req, err := http.NewRequest("PUT", u.String(), bytes.NewReader(reqBody))
+	req, err := http.NewRequest(http.MethodPut, u.String(), bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
@@ -93,7 +93,7 @@ func (w Witness) Update(ctx context.Context, logID string, cp []byte, proof [][]
 	if err != nil {
 		return nil, fmt.Errorf("failed to do http request: %v", err)
 	}
-	if resp.Request.Method != "PUT" {
+	if resp.Request.Method != http.MethodPut {
 		return nil, fmt.Errorf("PUT request to %q was converted to %s request to %q", u.String(), resp.Request.Method, resp.Request.URL)
 	}
 	defer resp.Body.Close()

--- a/internal/distribute/rest/distribute.go
+++ b/internal/distribute/rest/distribute.go
@@ -120,7 +120,7 @@ func (d *Distributor) distributeForLog(ctx context.Context, l config.Log) error 
 	if err != nil {
 		return fmt.Errorf("failed to parse URL: %v", err)
 	}
-	req, err := http.NewRequest("PUT", u.String(), bytes.NewReader(wRaw))
+	req, err := http.NewRequest(http.MethodPut, u.String(), bytes.NewReader(wRaw))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %v", err)
 	}
@@ -128,7 +128,7 @@ func (d *Distributor) distributeForLog(ctx context.Context, l config.Log) error 
 	if err != nil {
 		return fmt.Errorf("failed to do http request: %v", err)
 	}
-	if resp.Request.Method != "PUT" {
+	if resp.Request.Method != http.MethodPut {
 		return fmt.Errorf("PUT request to %q was converted to %s request to %q", u.String(), resp.Request.Method, resp.Request.URL)
 	}
 	defer resp.Body.Close()

--- a/internal/distribute/rest/distribute_test.go
+++ b/internal/distribute/rest/distribute_test.go
@@ -42,7 +42,7 @@ func TestDistributeOnce(t *testing.T) {
 	monitoring.SetMetricFactory(monitoring.InertMetricFactory{})
 	fd := &fakeDistributor{}
 	r := mux.NewRouter()
-	r.HandleFunc(fmt.Sprintf(rest.HTTPCheckpointByWitness, "{logid:[a-zA-Z0-9-]+}", "{witid:[^ +]+}"), fd.update).Methods("PUT")
+	r.HandleFunc(fmt.Sprintf(rest.HTTPCheckpointByWitness, "{logid:[a-zA-Z0-9-]+}", "{witid:[^ +]+}"), fd.update).Methods(http.MethodPut)
 	ts := httptest.NewServer(r)
 	defer ts.Close()
 

--- a/internal/feeder/pixelbt/pixel_feeder.go
+++ b/internal/feeder/pixelbt/pixel_feeder.go
@@ -124,7 +124,7 @@ func fetch(ctx context.Context, c *http.Client, base *url.URL, path string) ([]b
 		return nil, fmt.Errorf("failed to parse URL: %v", err)
 	}
 	klog.V(2).Infof("GET %s", u.String())
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}

--- a/internal/feeder/rekor/rekor_feeder.go
+++ b/internal/feeder/rekor/rekor_feeder.go
@@ -134,7 +134,7 @@ func getJSON(ctx context.Context, c *http.Client, base *url.URL, path string, s 
 	if err != nil {
 		return fmt.Errorf("failed to parse URL: %v", err)
 	}
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %v", err)
 	}

--- a/internal/feeder/serverless/serverless_feeder.go
+++ b/internal/feeder/serverless/serverless_feeder.go
@@ -88,7 +88,7 @@ func newFetcher(c *http.Client, root *url.URL) client.Fetcher {
 		fallthrough
 	case "https":
 		get = func(ctx context.Context, u *url.URL) ([]byte, error) {
-			req, err := http.NewRequest("GET", u.String(), nil)
+			req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -116,9 +116,9 @@ func (s *Server) getLogs(w http.ResponseWriter, r *http.Request) {
 // RegisterHandlers registers HTTP handlers for witness endpoints.
 func (s *Server) RegisterHandlers(r *mux.Router) {
 	logStr := "{logid:[a-zA-Z0-9-]+}"
-	r.HandleFunc(fmt.Sprintf(api.HTTPGetCheckpoint, logStr), s.getCheckpoint).Methods("GET")
-	r.HandleFunc(fmt.Sprintf(api.HTTPUpdate, logStr), s.update).Methods("PUT")
-	r.HandleFunc(api.HTTPGetLogs, s.getLogs).Methods("GET")
+	r.HandleFunc(fmt.Sprintf(api.HTTPGetCheckpoint, logStr), s.getCheckpoint).Methods(http.MethodGet)
+	r.HandleFunc(fmt.Sprintf(api.HTTPUpdate, logStr), s.update).Methods(http.MethodPut)
+	r.HandleFunc(api.HTTPGetLogs, s.getLogs).Methods(http.MethodGet)
 }
 
 func httpForCode(c codes.Code) int {


### PR DESCRIPTION
A redirect on a PUT request will make the http client perform a GET request to the signposted URL. This will (probably) return a 200, which the code will then interpret as a successful PUT. This check ensures that the method the response relates to is the same as the one we invoked.
