### PR TITLE
Add initial cut of a Bastion feeder

### DIFF
--- a/cmd/feedbastion/main.go
+++ b/cmd/feedbastion/main.go
@@ -1,0 +1,127 @@
+// Copyright 2024 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// feedbastion is a tool for submitting to witnesses behind bastions.
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"flag"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"time"
+
+	"github.com/transparency-dev/witness/internal/config"
+	"github.com/transparency-dev/witness/omniwitness"
+	"gopkg.in/yaml.v3"
+	"k8s.io/klog/v2"
+)
+
+var (
+	bastionURL  = flag.String("bastion_url", "https://localhost:8443", "URL of the bastion service")
+	httpTimeout = flag.Duration("http_timeout", 10*time.Second, "HTTP timeout for outbound requests")
+	feed        = flag.String("feed", ".*", "RegEx matching log origins to feed to bastion")
+)
+
+type logFeeder struct {
+	cfg  config.Log
+	info omniwitness.LogInfo
+}
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+	defer klog.Flush()
+
+	ctx := context.Background()
+
+	httpClient := &http.Client{}
+	insecureHttpClient := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	},
+	}
+	cfg := omniwitness.LogConfig{}
+	if err := yaml.Unmarshal(omniwitness.ConfigLogs, &cfg); err != nil {
+		klog.Exitf("failed to unmarshal witness config: %v", err)
+	}
+
+	feeders := make(map[string]logFeeder)
+	for _, l := range cfg.Logs {
+		lc, err := config.NewLog(l.Origin, l.PublicKey, l.URL)
+		if err != nil {
+			klog.Exitf("invalid log configuration: %v", err)
+		}
+		feeders[l.Origin] = logFeeder{
+			cfg:  lc,
+			info: l,
+		}
+	}
+
+	r := regexp.MustCompile(*feed)
+	bc := &bastionClient{
+		httpClient: insecureHttpClient,
+		url:        *bastionURL,
+	}
+	for o, lf := range feeders {
+		if r.Match([]byte(o)) {
+			if err := lf.info.Feeder.FeedFunc()(ctx, lf.cfg, bc, httpClient, 0); err != nil {
+				klog.Errorf("%v: %v", o, err)
+			}
+		}
+	}
+}
+
+type bastionClient struct {
+	httpClient *http.Client
+	url        string
+}
+
+// GetLatestCheckpoint returns the latest checkpoint the witness holds for the given logID.
+// Must return os.ErrNotExists if the logID is known, but it has no checkpoint for that log.
+func (b *bastionClient) GetLatestCheckpoint(ctx context.Context, logID string) ([]byte, error) {
+	// Unfortunately we don't have a way of getting this, so we'll just lie and pretend the witness has no checkpoints for this log.
+	return nil, os.ErrNotExist
+}
+
+// Update attempts to clock the witness forward for the given logID.
+// The latest signed checkpoint will be returned if this succeeds, or if the error is
+// http.ErrCheckpointTooOld. In all other cases no checkpoint should be expected.
+func (b *bastionClient) Update(ctx context.Context, logID string, newCP []byte, proof [][]byte) ([]byte, error) {
+	// The request body MUST be a sequence of
+	// - a previous size line,
+	// - zero or more consistency proof lines,
+	// - and an empty line,
+	// - followed by a [checkpoint][].
+	body := "old 0\n"
+	for _, p := range proof {
+		body += base64.StdEncoding.EncodeToString(p) + "\n"
+	}
+	body += "\n"
+	body += string(newCP)
+
+	klog.V(1).Infof("sending:\n%s", body)
+	resp, err := b.httpClient.Post(b.url, "", bytes.NewReader([]byte(body)))
+	if err != nil {
+		return nil, err
+	}
+	rb, err := io.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	klog.Infof("%v:\n%s", resp.Status, string(rb))
+	return nil, nil
+}

--- a/cmd/feedbastion/main.go
+++ b/cmd/feedbastion/main.go
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// feedbastion is a tool for submitting to witnesses behind bastions.
+// feedbastion is a one-shot tool for submitting checkpoints from known logs
+// to witnesses behind bastions.
+//
+// The primary use case for this tool is testing a bastion + witness setup.
 package main
 
 import (

--- a/cmd/feedbastion/main.go
+++ b/cmd/feedbastion/main.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"os"
 	"regexp"
-	"time"
 
 	"github.com/transparency-dev/witness/internal/config"
 	"github.com/transparency-dev/witness/omniwitness"
@@ -34,9 +33,8 @@ import (
 )
 
 var (
-	bastionURL  = flag.String("bastion_url", "https://localhost:8443", "URL of the bastion service")
-	httpTimeout = flag.Duration("http_timeout", 10*time.Second, "HTTP timeout for outbound requests")
-	feed        = flag.String("feed", ".*", "RegEx matching log origins to feed to bastion")
+	bastionURL = flag.String("bastion_url", "https://localhost:8443", "URL of the bastion service")
+	feed       = flag.String("feed", ".*", "RegEx matching log origins to feed to bastion")
 )
 
 type logFeeder struct {
@@ -121,6 +119,9 @@ func (b *bastionClient) Update(ctx context.Context, logID string, newCP []byte, 
 		return nil, err
 	}
 	rb, err := io.ReadAll(resp.Body)
+	if err != nil {
+		klog.Errorf("failed to read response body: %v", err)
+	}
 	defer resp.Body.Close()
 	klog.Infof("%v:\n%s", resp.Status, string(rb))
 	return nil, nil

--- a/cmd/feedbastion/main.go
+++ b/cmd/feedbastion/main.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"time"
 
 	"github.com/transparency-dev/witness/internal/config"
 	"github.com/transparency-dev/witness/omniwitness"
@@ -81,7 +82,8 @@ func main() {
 	}
 	for o, lf := range feeders {
 		if r.Match([]byte(o)) {
-			if err := lf.info.Feeder.FeedFunc()(ctx, lf.cfg, bc, httpClient, 0); err != nil {
+			oneShot := time.Duration(0)
+			if err := lf.info.Feeder.FeedFunc()(ctx, lf.cfg, bc, httpClient, oneShot); err != nil {
 				klog.Errorf("%v: %v", o, err)
 			}
 		}

--- a/cmd/omniwitness/README.md
+++ b/cmd/omniwitness/README.md
@@ -34,6 +34,36 @@ at https://play.golang.org/p/uWUKLNK6h9v. It is recommended to copy this code
 to your local machine and run from there in order to minimize the risk to the
 private key material.
 
+### Bastion Support
+
+This witness implementation supports synchronous witnessing via the [HTTPS bastion](https://github.com/C2SP/C2SP/blob/main/https-bastion.md) protocol.
+
+To enable this, two flags must be passed to `omniwitness`:
+
+1. `--bastion_addr` is the `host:port` of the bastion host to connect to.
+1. `--bastion_key_path` is the path to a file containing an ed25519 private key in PKCS8 PEM format.
+
+Although the witness key _could_ be reused, it's strongly recommended to use a separate key for this. Such a key can be generated with the following command:
+
+```bash
+openssl genpkey -algorith ed25519 -out ./my_bastion_private_key.pem
+```
+
+The bastion host operator will need to be given the hash of the corresponding public key bytes in order to provision the witness.
+
+The `omniwitness` prints this value out when it starts up:
+
+```text
+I0522 11:16:31.889534  758297 bastion_feeder.go:56] My bastion backend ID: 02b2442688cd1728f5c25c8425d69a915daddcfa4eb28a809a6b144b0ba889f3
+```
+
+Alternatively, the hash can be obtained with the following command:
+
+```bash
+$ openssl pkey -in ./my_bastion_private_key.pem -pubout -outform der | tail -c32 | sha256sum
+02b2442688cd1728f5c25c8425d69a915daddcfa4eb28a809a6b144b0ba889f3  -
+```
+
 ### GitHub Credentials
 
 This is optional, but recommended in order to push your checkpoints to as wide

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/prometheus/client_golang v1.19.1
 	github.com/transparency-dev/formats v0.0.0-20240610130149-01e8727bec75
 	github.com/transparency-dev/serverless-log v0.0.0-20240408141044-5d483a81bdb7
+	golang.org/x/net v0.22.0
 	k8s.io/klog/v2 v2.120.1
 )
 
@@ -32,5 +33,6 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
 )

--- a/internal/feeder/bastion/bastion_feeder.go
+++ b/internal/feeder/bastion/bastion_feeder.go
@@ -60,7 +60,6 @@ func FeedBastion(ctx context.Context, c Config, w feeder.Witness) error {
 		witVerifier: c.WitnessVerifier,
 	}
 	for _, l := range c.Logs {
-		l := l
 		h.logs[l.ID] = l
 	}
 
@@ -201,7 +200,6 @@ func connectAndServe(ctx context.Context, host string, handler http.Handler, key
 		}).DialContext(ctx, "tcp", host)
 		if err != nil {
 			klog.Infof("Failed to connect to bastion: %v", err)
-			time.Sleep(5 * time.Second)
 			continue
 		}
 

--- a/internal/feeder/bastion/bastion_feeder.go
+++ b/internal/feeder/bastion/bastion_feeder.go
@@ -1,0 +1,230 @@
+// Copyright 2024 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bastion is an implementation of a witness feeder which talks to a bastion server.
+package bastion
+
+import (
+	"bufio"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/transparency-dev/formats/log"
+	"github.com/transparency-dev/witness/internal/config"
+	"github.com/transparency-dev/witness/internal/feeder"
+	"golang.org/x/mod/sumdb/note"
+	"golang.org/x/net/http2"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
+)
+
+type Config struct {
+	Addr            string
+	Prefix          string
+	Logs            []config.Log
+	BastionKey      ed25519.PrivateKey
+	WitnessVerifier note.Verifier
+}
+
+// FeedBastion talks to the bastion to receive checkpoints to be witnessed.
+// This function returns once the provided context is done.
+func FeedBastion(ctx context.Context, c Config, w feeder.Witness) error {
+	klog.Infof("My bastion backend ID: %064x", sha256.Sum256(c.BastionKey.Public().(ed25519.PublicKey)))
+	h := &addHandler{
+		w:           w,
+		logs:        make(map[string]config.Log),
+		witVerifier: c.WitnessVerifier,
+	}
+	for _, l := range c.Logs {
+		l := l
+		h.logs[l.ID] = l
+	}
+
+	return connectAndServe(ctx, c.Addr, h, c.BastionKey)
+}
+
+type addHandler struct {
+	w           feeder.Witness
+	logs        map[string]config.Log
+	witVerifier note.Verifier
+}
+
+func (a *addHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	_, proof, cp, err := parseBody(r.Body)
+	if err != nil {
+		klog.V(1).Infof("invalid body: %v", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	s := strings.SplitN(string(cp), "\n", 2)
+	if len(s) != 2 {
+		klog.V(1).Infof("invalid cp: %v", cp)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	logID := log.ID(s[0])
+	logCfg, ok := a.logs[logID]
+	if !ok {
+		klog.V(1).Infof("unknown log: %v", logID)
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	signedCP, updateErr := a.w.Update(context.Background(), logID, cp, proof)
+	checkpoint, _, n, cpErr := log.ParseCheckpoint(signedCP, logCfg.Origin, a.witVerifier)
+
+	if updateErr != nil {
+		if sc := status.Code(err); sc == codes.FailedPrecondition {
+			// Invalid proof
+			klog.V(1).Infof("invalid proof: %v", err)
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		if sc := status.Code(err); sc == codes.AlreadyExists {
+			// old checkpoint is smaller than the latest the witness knows about
+			w.Header().Add("Content-Type", "text/x.tlog.size")
+			w.WriteHeader(http.StatusConflict)
+			if _, err := w.Write([]byte(fmt.Sprintf("%d\n", checkpoint.Size))); err != nil {
+				klog.V(1).Infof("Failed to write size response: %v", err)
+			}
+			return
+		}
+	}
+
+	if cpErr != nil {
+		klog.V(1).Infof("invalid checkpoint: %v", cpErr)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if _, err := w.Write([]byte(fmt.Sprintf("— %s %s\n", n.Sigs[0].Name, n.Sigs[0].Base64))); err != nil {
+		klog.V(1).Infof("Failed to write signature response: %v", err)
+	}
+}
+
+// parseBody reads the incoming request and parses into constituent parts.
+//
+// The request body MUST be a sequence of
+// - a previous size line,
+// - zero or more consistency proof lines,
+// - and an empty line,
+// - followed by a [checkpoint][].
+func parseBody(r io.Reader) (uint64, [][]byte, []byte, error) {
+	b := bufio.NewReader(r)
+	sizeLine, _, err := b.ReadLine()
+	if err != nil {
+		klog.Infof("read sizeline: %v", err)
+		return 0, nil, nil, err
+	}
+	var size uint64
+	if n, err := fmt.Sscanf(string(sizeLine), "old %d", &size); err != nil || n != 1 {
+		klog.Infof("scan sizeline: %v", err)
+		return 0, nil, nil, err
+	}
+	proof := [][]byte{}
+	for {
+		l, _, err := b.ReadLine()
+		if err != nil {
+			klog.Infof("read proofline: %v", err)
+			return 0, nil, nil, err
+		}
+		if len(l) == 0 {
+			break
+		}
+		hash, err := base64.StdEncoding.DecodeString(string(l))
+		if err != nil {
+			klog.Infof("base64 proof: %v", err)
+			return 0, nil, nil, err
+		}
+		proof = append(proof, hash)
+	}
+	cp, err := io.ReadAll(b)
+	if err != nil {
+		klog.Infof("read cp: %v", err)
+		return 0, nil, nil, err
+	}
+	return size, proof, cp, nil
+}
+
+func connectAndServe(ctx context.Context, host string, handler http.Handler, key ed25519.PrivateKey) error {
+	t := time.NewTicker(5 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C: // Don't spam bastion in a tight loop in case of error below.
+		}
+
+		cert, err := selfSignedCertificate(key)
+		if err != nil {
+			return err
+		}
+		klog.Infof("Connecting to bastion...")
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		conn, err := (&tls.Dialer{
+			Config: &tls.Config{
+				Certificates: []tls.Certificate{{
+					Certificate: [][]byte{cert},
+					PrivateKey:  key,
+				}},
+				MinVersion: tls.VersionTLS13,
+				MaxVersion: tls.VersionTLS13,
+				NextProtos: []string{"bastion/0"},
+			},
+		}).DialContext(ctx, "tcp", host)
+		if err != nil {
+			klog.Infof("Failed to connect to bastion: %v", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		klog.Infof("Connected to bastion. Serving connection...")
+		(&http2.Server{}).ServeConn(conn, &http2.ServeConnOpts{
+			Context: ctx,
+			Handler: handler,
+		})
+	}
+}
+
+func selfSignedCertificate(key ed25519.PrivateKey) ([]byte, error) {
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "Bastion backend"},
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	cert, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, key.Public(), key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate self-signed certificate: %v", err)
+	}
+	return cert, nil
+}

--- a/internal/feeder/bastion/bastion_feeder_test.go
+++ b/internal/feeder/bastion/bastion_feeder_test.go
@@ -1,0 +1,85 @@
+// Copyright 2024 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bastion
+
+import (
+	"bytes"
+	"encoding/base64"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+const (
+	testCP = "56\n7azctENRYLlBCBQ5OX2qxxIKCTOeCda1KfTwjdt0wdA=\n\n— transparency.dev-aw-ftlog-ci-2 93xidocoWXVph2jEuzW2oovU+IjU71+FeVGKtKXQknSla2HCvr6RYHRSdJfxpo4kj5geqxkjrDXcbpiSo7lK96X4Dgc=\n"
+)
+
+func TestParseBody(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		body            string
+		wantSize        uint64
+		wantConsistency [][]byte
+		wantCheckpoint  []byte
+		wantErr         bool
+	}{
+		{
+			name:            "ok",
+			body:            "old 10\nabc=\ndef=\n\n" + testCP,
+			wantSize:        10,
+			wantConsistency: [][]byte{d64(t, "abc="), d64(t, "def=")},
+			wantCheckpoint:  []byte(testCP),
+		}, {
+			name:    "Invalid previous size",
+			body:    "10 stuff\nabc=\ndef=\n\n" + testCP,
+			wantErr: true,
+		}, {
+			name:    "Invalid proof base64",
+			body:    "10\nZ043\n423ed\n" + testCP,
+			wantErr: true,
+		}, {
+			name:    "Missing proof terminator line",
+			body:    "10\nabc=\ndef=\n" + testCP,
+			wantErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s, c, cp, err := parseBody(bytes.NewBuffer([]byte(test.body)))
+			if err != nil {
+				if !test.wantErr {
+					t.Fatalf("parseBody: %v, want no err", err)
+				}
+			}
+			if got, want := s, test.wantSize; got != want {
+				t.Errorf("got size %d, want %d", got, want)
+			}
+			if got, want := c, test.wantConsistency; !cmp.Equal(got, want) {
+				t.Errorf("got proof %x, want %x", got, want)
+			}
+			if got, want := cp, test.wantCheckpoint; !cmp.Equal(got, want) {
+				t.Errorf("got proof %s, want %s", got, want)
+			}
+		})
+	}
+}
+
+func d64(t *testing.T, s string) []byte {
+	t.Helper()
+	r, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		t.Fatalf("Invalid test base64 %q: %v", s, err)
+	}
+	return r
+}

--- a/internal/feeder/sumdb/sumdb_feeder.go
+++ b/internal/feeder/sumdb/sumdb_feeder.go
@@ -82,7 +82,11 @@ func FeedLog(ctx context.Context, l config.Log, w feeder.Witness, c *http.Client
 		Witness:         w,
 	}
 
-	return feeder.Run(ctx, interval, opts)
+	if interval > 0 {
+		return feeder.Run(ctx, interval, opts)
+	}
+	_, err := feeder.FeedOnce(ctx, opts)
+	return err
 }
 
 // convertToSumDBTiles takes a NodeID pointing to a node within the overall log,


### PR DESCRIPTION
This PR adds:
- an initial version of a `Feeder` which knows how to interact with a `Bastion` host, as outlined in C2SP/C2SP#56.
- a simple tool to _feed_ witnesses behind a bastion.

```
❯ go run ./cmd/feedbastion --bastion_url=https://localhost:8443/8d95291650778b3c4d91c7a4b12d20877fa551c94366774f5bb484df2488c7ca/add
I0508 19:13:48.385216  472044 main.go:124] 200 OK:
— testwitness n3cVs9nAO2YAAAAACeRsjJ0gGB7IEtcCiedWMDAKooMjdNztQ73Vbp09q4IwdS011cSfjg0NmQ3XWismx/5OJSUh72rbdXgYctffDQ==
I0508 19:13:48.526615  472044 main.go:124] 200 OK:
— testwitness n3cVs9nAO2YAAAAAfYB3JUo6sCns+AynfHhAAG+u41iIZ83T8MFh+WhGDhB2l3HNBUzWWHl1GY8TzBFG9i0FzyVtc/GjplYMT0AMAw==
I0508 19:13:48.649482  472044 main.go:124] 200 OK:
— testwitness n3cVs9nAO2YAAAAArMAjHfYIo5JTd2UXV+Fe1G6kXXzM9u4A05kzccC9g2ToQuvS+mZJuvDNkqqGwmwQKz7ZivDlxb3tY4q4ap/oCA==
I0508 19:13:49.017468  472044 main.go:124] 200 OK:
— testwitness n3cVs9nAO2YAAAAALH9sE2Sl6XmoWLvQuiqVd60tVyKvBuVH95Pz7P3BhANUI2kSX+RQZ4dz6sEyb4X34+p90i5kf0Cv2ec8MBl8BQ==
I0508 19:13:49.583070  472044 main.go:124] 200 OK:
— testwitness n3cVs9rAO2YAAAAANhJdf442FfZQBUXy505zpZkK0OXI72r+oHQOKcJUBQMwacOoPupiIaX2ygObJNGqEqaDU0e123diwReQ2GpzAg==
I0508 19:13:49.620768  472044 main.go:124] 200 OK:
— testwitness n3cVs9nAO2YAAAAAZvfxf+Nbi5A0Ysfa/GYQrlx0dDrdipM0d4Khx3kB0QLP1p3cB68tgIYVRYF4zZP3x9/BWUWUjuR5ndyNmLySCg==
I0508 19:13:49.631211  472044 main.go:124] 200 OK:
— testwitness n3cVs9nAO2YAAAAAUXHXKP74ccZWCA2J4of2uSHZIf4VRvYR1PiecK7c0PAEREYukdj+ce9DBcgvLFC+7gvo3geCsoCsAkVVYk9DCQ==
I0508 19:13:49.687219  472044 main.go:124] 200 OK:
— testwitness n3cVs9nAO2YAAAAAsSbwg2c5aj84HWKTfW+HqPIpPY15lxoLJ2WRVg6rEsM/vowf9n9BCudYKYZfOG7KaL3pEYyo2QdR3e+zev+hCQ==
```

Towards transparency-dev/armored-witness/issues/253
