### PR TITLE
Bump merkle library to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/transparency-dev/witness
 
-go 1.22.0
-
-toolchain go1.22.6
+go 1.22.7
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0
@@ -11,7 +9,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.23
 	github.com/prometheus/client_golang v1.20.3
 	github.com/transparency-dev/formats v0.0.0-20240610130149-01e8727bec75
-	github.com/transparency-dev/merkle v0.0.2
+	github.com/transparency-dev/merkle v0.0.3-0.20240919113952-3c979d16ee14
 	github.com/transparency-dev/serverless-log v0.0.0-20240408141044-5d483a81bdb7
 	golang.org/x/mod v0.21.0
 	golang.org/x/net v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/transparency-dev/formats v0.0.0-20240610130149-01e8727bec75 h1:WkIZsg3naZmD/QjTGUnEgZGaORjd2wWDNe578p3Cf8Y=
 github.com/transparency-dev/formats v0.0.0-20240610130149-01e8727bec75/go.mod h1:HeZ6X/KU5IoblFoc4T54FRwfd3dUbNvIZSRrFVtXH18=
-github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
-github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
+github.com/transparency-dev/merkle v0.0.3-0.20240919113952-3c979d16ee14 h1:K8JqF1HyGDXfTdDHtHe7VsIzeuFEcfLhioOXaupKB+Q=
+github.com/transparency-dev/merkle v0.0.3-0.20240919113952-3c979d16ee14/go.mod h1:EoKPjljyIALg1rldsJwRQVKOJO7sLd6eUqki19ruI80=
 github.com/transparency-dev/serverless-log v0.0.0-20240408141044-5d483a81bdb7 h1:Caqvx+/b2hpuK5dHLMtKxoNsNhSf6JsT9m+7Xgk1z6Y=
 github.com/transparency-dev/serverless-log v0.0.0-20240408141044-5d483a81bdb7/go.mod h1:A+cQ9EQeah/Ua7JaMOAAKkCfyDZPsq74o+UgwqQEPsQ=
 golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=


### PR DESCRIPTION
This is primarily to pull in https://github.com/transparency-dev/merkle/pull/140 now to confirm it doesn't have any suprises while I'm still context loaded on the issue. Better that than it surprising someone down the road.
