### PR TITLE
Allow configuring bastion-only logs

### DIFF
--- a/omniwitness/configs_test.go
+++ b/omniwitness/configs_test.go
@@ -15,16 +15,29 @@
 package omniwitness_test
 
 import (
+	_ "embed"
 	"testing"
 
 	"github.com/transparency-dev/witness/omniwitness"
 	"gopkg.in/yaml.v3"
 )
 
-func Test(t *testing.T) {
+var (
+	// TestConfigLogs is the testing config logs file, useful for when checking
+	// features which are not yet used by the prod config.
+	// Its schema is LogConfig
+	//go:embed logs_test.yaml
+	testConfigLogs []byte
+)
+
+func testConfig(t *testing.T, cfg []byte) {
+	t.Helper()
 	logCfg := omniwitness.LogConfig{}
-	if err := yaml.Unmarshal(omniwitness.ConfigLogs, &logCfg); err != nil {
+	if err := yaml.Unmarshal(cfg, &logCfg); err != nil {
 		t.Fatal("failed to unmarshal config", err)
+	}
+	if len(logCfg.Logs) == 0 {
+		t.Fatal("no logs defined in config")
 	}
 	for _, l := range logCfg.Logs {
 		if l.Feeder == 0 {
@@ -34,4 +47,12 @@ func Test(t *testing.T) {
 			t.Errorf("log %q has no URL", l.URL)
 		}
 	}
+}
+
+func TestProdConfig(t *testing.T) {
+	testConfig(t, omniwitness.ConfigLogs)
+}
+
+func TestConfig(t *testing.T) {
+	testConfig(t, testConfigLogs)
 }

--- a/omniwitness/logs_test.yaml
+++ b/omniwitness/logs_test.yaml
@@ -1,0 +1,5 @@
+Logs:
+  - Origin: sigsum.org/v1/tree/c9e525b98f412ede185ff2ac5abf70920a2e63a6ae31c88b1138b85de328706b
+    URL: https://poc.sigsum.org/jellyfish
+    PublicKey: sigsum.org/v1/tree/c9e525b98f412ede185ff2ac5abf70920a2e63a6ae31c88b1138b85de328706b+d6c89be8+ARVPSZdrWf8JoSNnX1jLPjRuBFV1PDw7FdRl3LT2USsL
+    Feeder: none

--- a/omniwitness/omniwitness.go
+++ b/omniwitness/omniwitness.go
@@ -114,7 +114,9 @@ func Main(ctx context.Context, operatorConfig OperatorConfig, p LogStatePersiste
 		if err != nil {
 			return fmt.Errorf("invalid log configuration: %v", err)
 		}
-		feeders[lc] = l.Feeder.FeedFunc()
+		if l.Feeder != None {
+			feeders[lc] = l.Feeder.FeedFunc()
+		}
 		logs = append(logs, lc)
 	}
 
@@ -240,6 +242,7 @@ const (
 	SumDB
 	Pixel
 	Rekor
+	None
 )
 
 var (
@@ -248,6 +251,7 @@ var (
 		"sumdb":      SumDB,
 		"pixel":      Pixel,
 		"rekor":      Rekor,
+		"none":       None,
 	}
 )
 


### PR DESCRIPTION
This PR allows the `omniwitness` to be configured with logs which have no associated feeder, and will consequently only be updatable via the synchronous bastion protocol.