### PR TITLE
Log polling interval can be configured

### DIFF
--- a/cmd/omniwitness/README.md
+++ b/cmd/omniwitness/README.md
@@ -43,6 +43,9 @@ To enable this, two flags must be passed to `omniwitness`:
 1. `--bastion_addr` is the `host:port` of the bastion host to connect to.
 1. `--bastion_key_path` is the path to a file containing an ed25519 private key in PKCS8 PEM format.
 
+To run the witness in bastion-only mode, set the `--poll_interval` flag to 0.
+This will disable all attempts to poll logs, and witnessing will only occur via bastion connections.
+
 Although the witness key _could_ be reused, it's strongly recommended to use a separate key for this. Such a key can be generated with the following command:
 
 ```bash

--- a/cmd/omniwitness/monolith.go
+++ b/cmd/omniwitness/monolith.go
@@ -52,6 +52,8 @@ var (
 	bastionKeyPath         = flag.String("bastion_key_path", "", "Path to a file containing an ed25519 private key in PKCS8 PEM format")
 	bastionRateLimit       = flag.Float64("bastion_rate_limit", 20, "Maximum number of bastion requests per second to serve")
 	httpTimeout            = flag.Duration("http_timeout", 10*time.Second, "HTTP timeout for outbound requests")
+
+	pollInterval = flag.Duration("poll_interval", 1*time.Minute, "Time to wait between polling logs for new checkpoints. Set to 0 to disable polling logs.")
 )
 
 func main() {
@@ -107,6 +109,7 @@ func main() {
 		BastionAddr:            *bastionAddr,
 		BastionKey:             bastionKey,
 		BastionRateLimit:       *bastionRateLimit,
+		FeedInterval:           *pollInterval,
 	}
 	var p persistence.LogStatePersistence
 	if len(*dbFile) > 0 {


### PR DESCRIPTION
By allowing the poll interval to be configured in the monolith, the omniwitness operator can now control how often the witness will poll logs to look for new checkpoints. This includes disabling polling, which allows the witness to be deployed in a bastion-only mode.
