### PR TITLE
Fix witness c2sp spec issues

### DIFF
--- a/internal/feeder/bastion/bastion_feeder.go
+++ b/internal/feeder/bastion/bastion_feeder.go
@@ -148,49 +148,73 @@ func (a *addHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		counterBastionIncomingResponse.Inc(bastionID, "unknown", strconv.Itoa(http.StatusNotFound))
 		return
 	}
-	signedCP, updateErr := a.w.Update(r.Context(), logID, cp, proof)
 
-	if updateErr != nil {
-		if sc := status.Code(updateErr); sc == codes.FailedPrecondition {
-			// Invalid proof
-			klog.Infof("Invalid proof: %v\noldSize: %d\nnewCP:\n%s\nProof:\n%s", updateErr, oldSize, cp, proof)
-			w.WriteHeader(http.StatusForbidden)
-			counterBastionIncomingResponse.Inc(bastionID, logCfg.Origin, strconv.Itoa(http.StatusForbidden))
-			return
-		}
-		if sc := status.Code(updateErr); sc == codes.AlreadyExists {
-			// old checkpoint is smaller than the latest the witness knows about
-			checkpoint, _, _, cpErr := log.ParseCheckpoint(signedCP, logCfg.Origin, a.witVerifier)
-			if cpErr != nil {
-				klog.V(1).Infof("invalid checkpoint: %v", cpErr)
-				w.WriteHeader(http.StatusBadRequest)
-				counterBastionIncomingResponse.Inc(bastionID, logCfg.Origin, strconv.Itoa(http.StatusBadRequest))
-				return
-			}
-			w.Header().Add("Content-Type", "text/x.tlog.size")
-			w.WriteHeader(http.StatusConflict)
-			counterBastionIncomingResponse.Inc(bastionID, logCfg.Origin, strconv.Itoa(http.StatusConflict))
-			if _, err := w.Write([]byte(fmt.Sprintf("%d\n", checkpoint.Size))); err != nil {
-				klog.V(1).Infof("Failed to write size response: %v", err)
-			}
-			return
-		}
-	}
-
-	_, _, n, cpErr := log.ParseCheckpoint(signedCP, logCfg.Origin, a.witVerifier)
-	if cpErr != nil {
-		klog.V(1).Infof("invalid checkpoint: %v", cpErr)
-		w.WriteHeader(http.StatusBadRequest)
-		counterBastionIncomingResponse.Inc(bastionID, logCfg.Origin, strconv.Itoa(http.StatusBadRequest))
+	sc, body, contentType, err := a.handleUpdate(r.Context(), logID, logCfg.Origin, oldSize, cp, proof)
+	if err != nil {
+		klog.Errorf("handleUpdate: %v", err)
+		w.WriteHeader(sc)
+		counterBastionIncomingResponse.Inc(bastionID, logCfg.Origin, strconv.Itoa(sc))
 		return
 	}
 
-	if _, err := w.Write([]byte(fmt.Sprintf("— %s %s\n", n.Sigs[0].Name, n.Sigs[0].Base64))); err != nil {
-		klog.V(1).Infof("Failed to write signature response: %v", err)
+	if contentType != "" {
+		w.Header().Add("Content-Type", contentType)
+	}
+	w.WriteHeader(sc)
+	if len(body) > 0 {
+		if _, err := w.Write(body); err != nil {
+			klog.Errorf("Failed to write response body: %v", err)
+		}
+	}
+	counterBastionIncomingResponse.Inc(bastionID, logCfg.Origin, strconv.Itoa(sc))
+}
+
+func (a *addHandler) handleUpdate(ctx context.Context, logID string, origin string, oldSize uint64, newCP []byte, proof [][]byte) (int, []byte, string, error) {
+	trusted, updateErr := a.w.Update(ctx, logID, newCP, proof)
+	// Whatever happened, we usually get the latest trusted CP from the witness (whether it's the old one or the one we've just updated to).
+	// If we get nothing at all, then something's gone quite wrong.
+	if trusted == nil {
+		return http.StatusInternalServerError, nil, "", fmt.Errorf("something went quite wrong during update: %v", updateErr)
+	}
+	// We'll need to use the old CP when sending responses, so parse it once here:
+	trustedCP, _, n, cpErr := log.ParseCheckpoint(trusted, origin, a.witVerifier)
+	if cpErr != nil {
+		return http.StatusInternalServerError, nil, "", fmt.Errorf("invalid stored checkpoint!: %v", cpErr)
 	}
 
-	counterBastionIncomingResponse.Inc(bastionID, logCfg.Origin, strconv.Itoa(200))
+	// Finally, handle any "soft" error from the update:
+	if updateErr != nil {
+		switch sc := status.Code(updateErr); sc {
+		case codes.Unauthenticated:
+			// The proof is invalid somehow, this could be because the proof bytes are wrong, but it could also be that the log's idea of what the
+			// witness' current trusted checkpoint is wrong. So figure out which, and respond accordingly.
 
+			if trustedCP.Size != oldSize {
+				// The witness MUST check that the old size matches the size of the latest checkpoint it cosigned for the checkpoint's origin (or zero if it never
+				// cosigned a checkpoint for that origin). If it doesn't match, the witness MUST respond with a "409 Conflict" HTTP status code.
+				// The response body MUST consist of the tree size of the latest cosigned checkpoint in decimal, followed by a newline (U+000A).
+				// The response MUST have a Content-Type of text/x.tlog.size.
+				body := []byte(fmt.Sprintf("%d\n", trustedCP.Size))
+				return http.StatusConflict, body, "text/x.tlog.size", nil
+			}
+
+			// Invalid proof
+			// The consistency proof lines MUST encode a Merkle Consistency Proof from the old size to the checkpoint size according to RFC 6962, Section 2.1.2.
+			// The proof MUST be empty if the old size is zero.
+			// If the Merkle Consistency Proof doesn't verify, the witness MUST respond with a "422 Unprocessable Entity" HTTP status code.
+			return http.StatusUnprocessableEntity, nil, "", nil
+		case codes.FailedPrecondition:
+			// If the old size matches the checkpoint size, the witness MUST check that the root hashes are also identical.
+			// If they don't match, the witness MUST respond with a "409 Conflict" HTTP status code.
+			return http.StatusConflict, nil, "", nil
+		case codes.AlreadyExists:
+			body := []byte(fmt.Sprintf("%d\n", trustedCP.Size))
+			return http.StatusConflict, body, "text/x.tlog.size", nil
+		}
+	}
+
+	body := []byte(fmt.Sprintf("— %s %s\n", n.Sigs[0].Name, n.Sigs[0].Base64))
+	return http.StatusOK, body, "", nil
 }
 
 // parseBody reads the incoming request and parses into constituent parts.

--- a/internal/feeder/bastion/bastion_feeder_test.go
+++ b/internal/feeder/bastion/bastion_feeder_test.go
@@ -16,15 +16,29 @@ package bastion
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
+	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/transparency-dev/formats/note"
+	"github.com/transparency-dev/witness/internal/config"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
-	testCP = "56\n7azctENRYLlBCBQ5OX2qxxIKCTOeCda1KfTwjdt0wdA=\n\n— transparency.dev-aw-ftlog-ci-2 93xidocoWXVph2jEuzW2oovU+IjU71+FeVGKtKXQknSla2HCvr6RYHRSdJfxpo4kj5geqxkjrDXcbpiSo7lK96X4Dgc=\n"
+	testCPOrigin = "transparency.dev/armored-witness/firmware_transparency/ci/2"
+	testCPSize   = 56
+	testCPRoot   = "7azctENRYLlBCBQ5OX2qxxIKCTOeCda1KfTwjdt0wdA="
+	testCPSig    = "— transparency.dev-aw-ftlog-ci-2 93xidocoWXVph2jEuzW2oovU+IjU71+FeVGKtKXQknSla2HCvr6RYHRSdJfxpo4kj5geqxkjrDXcbpiSo7lK96X4Dgc=\n"
+
+	testCPVerifier = "transparency.dev-aw-ftlog-ci-2+f77c6276+AZXqiaARpwF4MoNOxx46kuiIRjrML0PDTm+c7BLaAMt6"
 )
+
+var testCP = fmt.Sprintf("%s\n%d\n%s\n\n%s", testCPOrigin, testCPSize, testCPRoot, testCPSig)
 
 func TestParseBody(t *testing.T) {
 	for _, test := range []struct {
@@ -73,6 +87,108 @@ func TestParseBody(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandler(t *testing.T) {
+	v, err := note.NewVerifier(testCPVerifier)
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	logID := "logID"
+	logs := map[string]config.Log{
+		logID: config.Log{Origin: testCPOrigin},
+	}
+	for _, test := range []struct {
+		// params
+		name    string
+		logID   string
+		oldSize uint64
+		// fake witness control
+		witnessResp []byte
+		witnessErr  error
+		// responses
+		wantBody        string
+		wantStatus      int
+		wantContentType string
+	}{
+		{
+			name:        "works - accepted by witness",
+			logID:       "logID",
+			witnessResp: []byte(testCP),
+			wantStatus:  200,
+			wantBody:    testCPSig,
+		}, {
+			name:            "new CP smaller than existing",
+			logID:           "logID",
+			witnessResp:     []byte(testCP),
+			witnessErr:      status.Errorf(codes.AlreadyExists, "test error"),
+			wantStatus:      http.StatusConflict,
+			wantContentType: "text/x.tlog.size",
+			wantBody:        fmt.Sprintf("%d\n", testCPSize),
+		}, {
+			name:        "invalid proof",
+			logID:       "logID",
+			oldSize:     testCPSize,
+			witnessResp: []byte(testCP),
+			witnessErr:  status.Errorf(codes.Unauthenticated, "test error"),
+			wantStatus:  http.StatusUnprocessableEntity,
+		}, {
+			name:            "incorrect oldCP size",
+			logID:           "logID",
+			oldSize:         testCPSize - 10,
+			witnessResp:     []byte(testCP),
+			witnessErr:      status.Errorf(codes.Unauthenticated, "test error"),
+			wantStatus:      http.StatusConflict,
+			wantContentType: "text/x.tlog.size",
+			wantBody:        fmt.Sprintf("%d\n", testCPSize),
+		}, {
+			name:        "same size, different roots",
+			logID:       "logID",
+			oldSize:     testCPSize,
+			witnessResp: []byte(testCP),
+			witnessErr:  status.Errorf(codes.FailedPrecondition, "test error"),
+			wantStatus:  http.StatusConflict,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			a := addHandler{
+				w:           &testWitness{updateResponse: test.witnessResp, updateErr: test.witnessErr},
+				witVerifier: v,
+				logs:        logs,
+			}
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			sc, body, ct, err := a.handleUpdate(context.Background(), test.logID, testCPOrigin, test.oldSize, []byte(testCP), [][]byte{})
+			if err != nil {
+				t.Fatalf("handleUpdate: %v", err)
+			}
+			if got, want := sc, test.wantStatus; got != want {
+				t.Errorf("handleUpdate got status %d, want %d", got, want)
+			}
+			if got, want := ct, test.wantContentType; got != want {
+				t.Errorf("handleUpdate got content type %q, want %q", got, want)
+			}
+			if got, want := string(body), test.wantBody; got != want {
+				t.Errorf("handleUpdate got body %q, %q", got, want)
+			}
+		})
+	}
+}
+
+type testWitness struct {
+	latestCPErr    error
+	latestCP       []byte
+	updateErr      error
+	updateResponse []byte
+}
+
+func (tw *testWitness) GetLatestCheckpoint(ctx context.Context, logID string) ([]byte, error) {
+	return tw.latestCP, tw.latestCPErr
+}
+
+func (tw *testWitness) Update(ctx context.Context, logID string, newCP []byte, proof [][]byte) ([]byte, error) {
+	return tw.updateResponse, tw.updateErr
 }
 
 func d64(t *testing.T, s string) []byte {

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -127,7 +127,7 @@ func httpForCode(c codes.Code) int {
 		return http.StatusConflict
 	case codes.NotFound:
 		return http.StatusNotFound
-	case codes.FailedPrecondition, codes.InvalidArgument:
+	case codes.FailedPrecondition, codes.InvalidArgument, codes.Unauthenticated:
 		return http.StatusBadRequest
 	default:
 		return http.StatusInternalServerError

--- a/internal/witness/witness.go
+++ b/internal/witness/witness.go
@@ -226,7 +226,7 @@ func (w *Witness) Update(ctx context.Context, logID string, nextRaw []byte, cPro
 	if err := proof.VerifyConsistency(logInfo.Hasher, prev.Size, next.Size, cProof, prev.Hash, next.Hash); err != nil {
 		// Complain if the checkpoints aren't consistent.
 		counterInvalidConsistency.Inc(logID)
-		return prevRaw, status.Errorf(codes.FailedPrecondition, "failed to verify consistency proof: %v", err)
+		return prevRaw, status.Errorf(codes.Unauthenticated, "failed to verify consistency proof: %v", err)
 	}
 	// If the consistency proof is good we store the witness cosigned nextRaw.
 	signed, err := w.signChkpt(nextNote)


### PR DESCRIPTION
This PR tries to fix the spec compliance issues in the witness while leaving the witness internal API mostly alone.

A better fix would be to re-do the internal API to better line up with the spec, but that's a bit more of an invasive change.

Raising this to use as a starting point for discussion.

#321 