### PR TITLE
Fix C2SP compliance and simplify

### DIFF
--- a/api/http.go
+++ b/api/http.go
@@ -31,6 +31,7 @@ const (
 // checkpoint byte slice and a consistency proof (slice of slices).  The logID
 // is part of the request URL.
 type UpdateRequest struct {
+	OldSize    uint64
 	Checkpoint []byte
 	Proof      [][]byte
 }

--- a/cmd/feedbastion/main.go
+++ b/cmd/feedbastion/main.go
@@ -122,7 +122,7 @@ func (b *bastionClient) GetLatestCheckpoint(ctx context.Context, logID string) (
 // Update attempts to clock the witness forward for the given logID.
 // The latest signed checkpoint will be returned if this succeeds, or if the error is
 // http.ErrCheckpointTooOld. In all other cases no checkpoint should be expected.
-func (b *bastionClient) Update(ctx context.Context, logID string, newCP []byte, proof [][]byte) ([]byte, error) {
+func (b *bastionClient) Update(ctx context.Context, logID string, oldSize uint64, newCP []byte, proof [][]byte) ([]byte, error) {
 	// The request body MUST be a sequence of
 	// - a previous size line,
 	// - zero or more consistency proof lines,

--- a/internal/feeder/bastion/bastion_feeder.go
+++ b/internal/feeder/bastion/bastion_feeder.go
@@ -148,49 +148,71 @@ func (a *addHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		counterBastionIncomingResponse.Inc(bastionID, "unknown", strconv.Itoa(http.StatusNotFound))
 		return
 	}
-	signedCP, updateErr := a.w.Update(r.Context(), logID, cp, proof)
 
-	if updateErr != nil {
-		if sc := status.Code(updateErr); sc == codes.FailedPrecondition {
-			// Invalid proof
-			klog.Infof("Invalid proof: %v\noldSize: %d\nnewCP:\n%s\nProof:\n%s", updateErr, oldSize, cp, proof)
-			w.WriteHeader(http.StatusForbidden)
-			counterBastionIncomingResponse.Inc(bastionID, logCfg.Origin, strconv.Itoa(http.StatusForbidden))
-			return
-		}
-		if sc := status.Code(updateErr); sc == codes.AlreadyExists {
-			// old checkpoint is smaller than the latest the witness knows about
-			checkpoint, _, _, cpErr := log.ParseCheckpoint(signedCP, logCfg.Origin, a.witVerifier)
-			if cpErr != nil {
-				klog.V(1).Infof("invalid checkpoint: %v", cpErr)
-				w.WriteHeader(http.StatusBadRequest)
-				counterBastionIncomingResponse.Inc(bastionID, logCfg.Origin, strconv.Itoa(http.StatusBadRequest))
-				return
-			}
-			w.Header().Add("Content-Type", "text/x.tlog.size")
-			w.WriteHeader(http.StatusConflict)
-			counterBastionIncomingResponse.Inc(bastionID, logCfg.Origin, strconv.Itoa(http.StatusConflict))
-			if _, err := w.Write([]byte(fmt.Sprintf("%d\n", checkpoint.Size))); err != nil {
-				klog.V(1).Infof("Failed to write size response: %v", err)
-			}
-			return
-		}
-	}
-
-	_, _, n, cpErr := log.ParseCheckpoint(signedCP, logCfg.Origin, a.witVerifier)
-	if cpErr != nil {
-		klog.V(1).Infof("invalid checkpoint: %v", cpErr)
-		w.WriteHeader(http.StatusBadRequest)
-		counterBastionIncomingResponse.Inc(bastionID, logCfg.Origin, strconv.Itoa(http.StatusBadRequest))
+	sc, body, contentType, err := a.handleUpdate(r.Context(), logID, logCfg.Origin, oldSize, cp, proof)
+	if err != nil {
+		klog.Errorf("handleUpdate: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		counterBastionIncomingResponse.Inc(bastionID, logCfg.Origin, strconv.Itoa(http.StatusInternalServerError))
 		return
 	}
 
-	if _, err := w.Write([]byte(fmt.Sprintf("— %s %s\n", n.Sigs[0].Name, n.Sigs[0].Base64))); err != nil {
-		klog.V(1).Infof("Failed to write signature response: %v", err)
+	if contentType != "" {
+		w.Header().Add("Content-Type", "text/x.tlog.size")
+	}
+	w.WriteHeader(sc)
+	if len(body) > 0 {
+		w.Write(body)
+	}
+	counterBastionIncomingResponse.Inc(bastionID, logCfg.Origin, strconv.Itoa(sc))
+}
+
+func (a *addHandler) handleUpdate(ctx context.Context, logID string, origin string, oldSize uint64, newCP []byte, proof [][]byte) (int, []byte, string, error) {
+	trusted, updateErr := a.w.Update(ctx, logID, newCP, proof)
+	// Whatever happened, we usually get the latest trusted CP from the witness (whether it's the old one or the one we've just updated to).
+	// If we get nothing at all, then something's gone quite wrong.
+	if trusted == nil {
+		return http.StatusInternalServerError, nil, "", fmt.Errorf("something went quite wrong during update: %v", updateErr)
+	}
+	// We'll need to use the old CP when sending responses, so parse it once here:
+	trustedCP, _, n, cpErr := log.ParseCheckpoint(trusted, origin, a.witVerifier)
+	if cpErr != nil {
+		return http.StatusInternalServerError, nil, "", fmt.Errorf("invalid stored checkpoint!: %v", cpErr)
 	}
 
-	counterBastionIncomingResponse.Inc(bastionID, logCfg.Origin, strconv.Itoa(200))
+	// Finally, handle any "soft" error from the update:
+	if updateErr != nil {
+		switch sc := status.Code(updateErr); sc {
+		case codes.Unauthenticated:
+			// The proof is invalid somehow, this could be because the proof bytes are wrong, but it could also be that the log's idea of what the
+			// witness' current trusted checkpoint is wrong. So figure out which, and respond accordingly.
 
+			if trustedCP.Size != oldSize {
+				// The witness MUST check that the old size matches the size of the latest checkpoint it cosigned for the checkpoint's origin (or zero if it never
+				// cosigned a checkpoint for that origin). If it doesn't match, the witness MUST respond with a "409 Conflict" HTTP status code.
+				// The response body MUST consist of the tree size of the latest cosigned checkpoint in decimal, followed by a newline (U+000A).
+				// The response MUST have a Content-Type of text/x.tlog.size.
+				body := []byte(fmt.Sprintf("%d\n", trustedCP.Size))
+				return http.StatusConflict, body, "text/x.tlog.size", nil
+			}
+
+			// Invalid proof
+			// The consistency proof lines MUST encode a Merkle Consistency Proof from the old size to the checkpoint size according to RFC 6962, Section 2.1.2.
+			// The proof MUST be empty if the old size is zero.
+			// If the Merkle Consistency Proof doesn't verify, the witness MUST respond with a "422 Unprocessable Entity" HTTP status code.
+			return http.StatusUnprocessableEntity, nil, "", nil
+		case codes.FailedPrecondition:
+			// If the old size matches the checkpoint size, the witness MUST check that the root hashes are also identical.
+			// If they don't match, the witness MUST respond with a "409 Conflict" HTTP status code.
+			return http.StatusConflict, nil, "", nil
+		case codes.AlreadyExists:
+			body := []byte(fmt.Sprintf("%d\n", trustedCP.Size))
+			return http.StatusConflict, body, "text/x.tlog.size", nil
+		}
+	}
+
+	body := []byte(fmt.Sprintf("— %s %s\n", n.Sigs[0].Name, n.Sigs[0].Base64))
+	return http.StatusOK, body, "", nil
 }
 
 // parseBody reads the incoming request and parses into constituent parts.

--- a/internal/feeder/bastion/bastion_feeder.go
+++ b/internal/feeder/bastion/bastion_feeder.go
@@ -157,7 +157,7 @@ func (a *addHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if contentType != "" {
-		w.Header().Add("Content-Type", "text/x.tlog.size")
+		w.Header().Add("Content-Type", contentType)
 	}
 	w.WriteHeader(sc)
 	if len(body) > 0 {

--- a/internal/feeder/bastion/bastion_feeder.go
+++ b/internal/feeder/bastion/bastion_feeder.go
@@ -161,7 +161,9 @@ func (a *addHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(sc)
 	if len(body) > 0 {
-		w.Write(body)
+		if _, err := w.Write(body); err != nil {
+			klog.Infof("Failed to write response body: %v", err)
+		}
 	}
 	counterBastionIncomingResponse.Inc(bastionID, logCfg.Origin, strconv.Itoa(sc))
 }

--- a/internal/feeder/bastion/bastion_feeder_test.go
+++ b/internal/feeder/bastion/bastion_feeder_test.go
@@ -16,15 +16,30 @@ package bastion
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
+	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/transparency-dev/formats/note"
+	"github.com/transparency-dev/witness/internal/config"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
-	testCP = "56\n7azctENRYLlBCBQ5OX2qxxIKCTOeCda1KfTwjdt0wdA=\n\n— transparency.dev-aw-ftlog-ci-2 93xidocoWXVph2jEuzW2oovU+IjU71+FeVGKtKXQknSla2HCvr6RYHRSdJfxpo4kj5geqxkjrDXcbpiSo7lK96X4Dgc=\n"
+	testCPOrigin = "transparency.dev/armored-witness/firmware_transparency/ci/2"
+	testCPSize   = 56
+	testCPRoot   = "7azctENRYLlBCBQ5OX2qxxIKCTOeCda1KfTwjdt0wdA="
+	testCPSig    = "— transparency.dev-aw-ftlog-ci-2 93xidocoWXVph2jEuzW2oovU+IjU71+FeVGKtKXQknSla2HCvr6RYHRSdJfxpo4kj5geqxkjrDXcbpiSo7lK96X4Dgc=\n"
+
+	//testCP         = "transparency.dev/armored-witness/firmware_transparency/ci/2\n56\n7azctENRYLlBCBQ5OX2qxxIKCTOeCda1KfTwjdt0wdA=\n\n— transparency.dev-aw-ftlog-ci-2 93xidocoWXVph2jEuzW2oovU+IjU71+FeVGKtKXQknSla2HCvr6RYHRSdJfxpo4kj5geqxkjrDXcbpiSo7lK96X4Dgc=\n"
+	testCPVerifier = "transparency.dev-aw-ftlog-ci-2+f77c6276+AZXqiaARpwF4MoNOxx46kuiIRjrML0PDTm+c7BLaAMt6"
 )
+
+var testCP = fmt.Sprintf("%s\n%d\n%s\n\n%s", testCPOrigin, testCPSize, testCPRoot, testCPSig)
 
 func TestParseBody(t *testing.T) {
 	for _, test := range []struct {
@@ -73,6 +88,108 @@ func TestParseBody(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandler(t *testing.T) {
+	v, err := note.NewVerifier(testCPVerifier)
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	logID := "logID"
+	logs := map[string]config.Log{
+		logID: config.Log{Origin: testCPOrigin},
+	}
+	for _, test := range []struct {
+		// params
+		name    string
+		logID   string
+		oldSize uint64
+		// fake witness control
+		witnessResp []byte
+		witnessErr  error
+		// responses
+		wantBody        string
+		wantStatus      int
+		wantContentType string
+	}{
+		{
+			name:        "works - accepted by witness",
+			logID:       "logID",
+			witnessResp: []byte(testCP),
+			wantStatus:  200,
+			wantBody:    testCPSig,
+		}, {
+			name:            "new CP smaller than existing",
+			logID:           "logID",
+			witnessResp:     []byte(testCP),
+			witnessErr:      status.Errorf(codes.AlreadyExists, "test error"),
+			wantStatus:      http.StatusConflict,
+			wantContentType: "text/x.tlog.size",
+			wantBody:        fmt.Sprintf("%d\n", testCPSize),
+		}, {
+			name:        "invalid proof",
+			logID:       "logID",
+			oldSize:     testCPSize,
+			witnessResp: []byte(testCP),
+			witnessErr:  status.Errorf(codes.Unauthenticated, "test error"),
+			wantStatus:  http.StatusUnprocessableEntity,
+		}, {
+			name:            "incorrect oldCP size",
+			logID:           "logID",
+			oldSize:         testCPSize - 10,
+			witnessResp:     []byte(testCP),
+			witnessErr:      status.Errorf(codes.Unauthenticated, "test error"),
+			wantStatus:      http.StatusConflict,
+			wantContentType: "text/x.tlog.size",
+			wantBody:        fmt.Sprintf("%d\n", testCPSize),
+		}, {
+			name:        "same size, different roots",
+			logID:       "logID",
+			oldSize:     testCPSize,
+			witnessResp: []byte(testCP),
+			witnessErr:  status.Errorf(codes.FailedPrecondition, "test error"),
+			wantStatus:  http.StatusConflict,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			a := addHandler{
+				w:           &testWitness{updateResponse: test.witnessResp, updateErr: test.witnessErr},
+				witVerifier: v,
+				logs:        logs,
+			}
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			sc, body, ct, err := a.handleUpdate(context.Background(), test.logID, testCPOrigin, test.oldSize, []byte(testCP), [][]byte{})
+			if err != nil {
+				t.Fatalf("handleUpdate: %v", err)
+			}
+			if got, want := sc, test.wantStatus; got != want {
+				t.Errorf("handleUpdate got status %d, want %d", got, want)
+			}
+			if got, want := ct, test.wantContentType; got != want {
+				t.Errorf("handleUpdate got content type %q, want %q", got, want)
+			}
+			if got, want := string(body), test.wantBody; got != want {
+				t.Errorf("handleUpdate got body %q, %q", got, want)
+			}
+		})
+	}
+}
+
+type testWitness struct {
+	latestCPErr    error
+	latestCP       []byte
+	updateErr      error
+	updateResponse []byte
+}
+
+func (tw *testWitness) GetLatestCheckpoint(ctx context.Context, logID string) ([]byte, error) {
+	return tw.latestCP, tw.latestCPErr
+}
+
+func (tw *testWitness) Update(ctx context.Context, logID string, newCP []byte, proof [][]byte) ([]byte, error) {
+	return tw.updateResponse, tw.updateErr
 }
 
 func d64(t *testing.T, s string) []byte {

--- a/internal/feeder/feeder_test.go
+++ b/internal/feeder/feeder_test.go
@@ -134,7 +134,7 @@ func (fw *fakeWitness) GetLatestCheckpoint(_ context.Context, logID string) ([]b
 	return fw.latestCP, nil
 }
 
-func (fw *fakeWitness) Update(_ context.Context, logID string, newCP []byte, proof [][]byte) ([]byte, error) {
+func (fw *fakeWitness) Update(_ context.Context, logID string, oldSize uint64, newCP []byte, proof [][]byte) ([]byte, error) {
 	if fw.rejectUpdate {
 		return nil, errors.New("computer says 'no'")
 	}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -127,7 +127,7 @@ func httpForCode(c codes.Code) int {
 		return http.StatusConflict
 	case codes.NotFound:
 		return http.StatusNotFound
-	case codes.FailedPrecondition, codes.InvalidArgument:
+	case codes.FailedPrecondition, codes.InvalidArgument, codes.Unauthenticated:
 		return http.StatusBadRequest
 	default:
 		return http.StatusInternalServerError

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -18,7 +18,6 @@ package http
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -38,56 +37,6 @@ type Server struct {
 func NewServer(witness *witness.Witness) *Server {
 	return &Server{
 		w: witness,
-	}
-}
-
-// update handles requests to update checkpoints.
-// It expects a POSTed body containing a JSON-formatted api.UpdateRequest
-// statement and returns a JSON-formatted api.UpdateResponse statement.
-func (s *Server) update(w http.ResponseWriter, r *http.Request) {
-	v := mux.Vars(r)
-	logID := v["logid"]
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("cannot read request body: %v", err.Error()), http.StatusBadRequest)
-		return
-	}
-	var req api.UpdateRequest
-	if err := json.Unmarshal(body, &req); err != nil {
-		http.Error(w, fmt.Sprintf("cannot parse request body as proper JSON struct: %v", err.Error()), http.StatusBadRequest)
-		return
-	}
-	// Get the output from the witness.
-	chkpt, err := s.w.Update(r.Context(), logID, req.OldSize, req.Checkpoint, req.Proof)
-	if err != nil {
-		switch err {
-		case witness.ErrCheckpointStale:
-			w.Header().Set("X-Content-Type-Options", "nosniff")
-			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-			w.WriteHeader(http.StatusConflict)
-			if _, err := w.Write(chkpt); err != nil {
-				klog.Warningf("Error writing response: %v", err)
-			}
-		case witness.ErrUnknownLog:
-			http.Error(w, err.Error(), http.StatusNotFound)
-		case witness.ErrNoValidSignature:
-			http.Error(w, err.Error(), http.StatusForbidden)
-		case witness.ErrOldSizeInvalid:
-			http.Error(w, err.Error(), http.StatusBadRequest)
-		case witness.ErrInvalidProof:
-			http.Error(w, err.Error(), http.StatusUnprocessableEntity)
-		case witness.ErrRootMismatch:
-			http.Error(w, err.Error(), http.StatusConflict)
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		return
-	}
-
-	w.Header().Set("X-Content-Type-Options", "nosniff")
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	if _, err := w.Write(chkpt); err != nil {
-		klog.Warningf("Error writing response: %v", err)
 	}
 }
 
@@ -129,7 +78,6 @@ func (s *Server) getLogs(w http.ResponseWriter, r *http.Request) {
 func (s *Server) RegisterHandlers(r *mux.Router) {
 	logStr := "{logid:[a-zA-Z0-9-]+}"
 	r.HandleFunc(fmt.Sprintf(api.HTTPGetCheckpoint, logStr), s.getCheckpoint).Methods(http.MethodGet)
-	r.HandleFunc(fmt.Sprintf(api.HTTPUpdate, logStr), s.update).Methods(http.MethodPut)
 	r.HandleFunc(api.HTTPGetLogs, s.getLogs).Methods(http.MethodGet)
 }
 

--- a/internal/http/server_test.go
+++ b/internal/http/server_test.go
@@ -16,7 +16,6 @@ package http
 
 import (
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -38,18 +37,11 @@ import (
 )
 
 var (
-	mPK       = "monkeys+87be2a55+AeK/t7elVrIheVCPxQNYkvKFw/2ahkj6Gm9afBJw6S8q"
-	bPK       = "bananas+cf639f13+AaPjhFnPCQnid/Ql32KWhmh+uk72FVRfK+2DLmO3BI3M"
-	wSK       = "PRIVATE+KEY+witness+f13a86db+AaLa/dfyBhyo/m0Z7WCi98ENVZWtrP8pxgRNrx7tIWiA"
-	mInit     = []byte("Log Checkpoint v0\n5\n41smjBUiAU70EtKlT6lIOIYtRTYxYXsDB+XHfcvu/BE=\n\n— monkeys h74qVe5jWoK8CX/zXrT9X80SyEaiwPb/0p7VW7u+cnXxq5pJYQ6vhxUZ5Ywz9WSD3HIyygccizAg+oMxOe6pRgqqOQE=\n")
-	bInit     = []byte("Log Checkpoint v0\n5\n41smjBUiAU70EtKlT6lIOIYtRTYxYXsDB+XHfcvu/BE=\n\n— bananas z2OfE18+NwUjjJBXH7m+fh67bu29p1Jbypr4GFUQohgQgCeuPJZtGTvfR9Pquh2Iebfq+6bhl3G/77lsKiGIea6NAwE=\n")
-	mNext     = []byte("Log Checkpoint v0\n8\nV8K9aklZ4EPB+RMOk1/8VsJUdFZR77GDtZUQq84vSbo=\n\n— monkeys h74qVetPycmWeWIySx/cMKcLopNS9h2je2DWe2w7PLRmczqdqinRGPscYklpBQO5Un6B5eUMJDwZprVpJie0lSBNPg8=\n")
-	consProof = [][]byte{
-		dh("b9e1d62618f7fee8034e4c5010f727ab24d8e4705cb296c374bf2025a87a10d2", 32),
-		dh("aac66cd7a79ce4012d80762fe8eec3a77f22d1ca4145c3f4cee022e7efcd599d", 32),
-		dh("89d0f753f66a290c483b39cd5e9eafb12021293395fad3d4a2ad053cfbcfdc9e", 32),
-		dh("29e40bb79c966f4c6fe96aff6f30acfce5f3e8d84c02215175d6e018a5dee833", 32),
-	}
+	mPK   = "monkeys+87be2a55+AeK/t7elVrIheVCPxQNYkvKFw/2ahkj6Gm9afBJw6S8q"
+	bPK   = "bananas+cf639f13+AaPjhFnPCQnid/Ql32KWhmh+uk72FVRfK+2DLmO3BI3M"
+	wSK   = "PRIVATE+KEY+witness+f13a86db+AaLa/dfyBhyo/m0Z7WCi98ENVZWtrP8pxgRNrx7tIWiA"
+	mInit = []byte("Log Checkpoint v0\n5\n41smjBUiAU70EtKlT6lIOIYtRTYxYXsDB+XHfcvu/BE=\n\n— monkeys h74qVe5jWoK8CX/zXrT9X80SyEaiwPb/0p7VW7u+cnXxq5pJYQ6vhxUZ5Ywz9WSD3HIyygccizAg+oMxOe6pRgqqOQE=\n")
+	bInit = []byte("Log Checkpoint v0\n5\n41smjBUiAU70EtKlT6lIOIYtRTYxYXsDB+XHfcvu/BE=\n\n— bananas z2OfE18+NwUjjJBXH7m+fh67bu29p1Jbypr4GFUQohgQgCeuPJZtGTvfR9Pquh2Iebfq+6bhl3G/77lsKiGIea6NAwE=\n")
 )
 
 const logOrigin = "Log Checkpoint v0"
@@ -91,18 +83,6 @@ func newWitness(t *testing.T, logs []logOpts) *witness.Witness {
 		t.Fatalf("couldn't create witness: %v", err)
 	}
 	return w
-}
-
-// dh is taken from https://github.com/google/trillian/blob/master/merkle/logverifier/log_verifier_test.go.
-func dh(h string, expLen int) []byte {
-	r, err := hex.DecodeString(h)
-	if err != nil {
-		panic(err)
-	}
-	if got := len(r); got != expLen {
-		panic(fmt.Sprintf("decode %q: len=%d, want %d", h, got, expLen))
-	}
-	return r
 }
 
 func createTestEnv(w *witness.Witness) (*httptest.Server, func()) {

--- a/internal/witness/witness.go
+++ b/internal/witness/witness.go
@@ -52,7 +52,7 @@ var (
 	// ErrOldSizeInvalid is returned by calls to Update if the provided oldSize parameter is larger than the size of the
 	// submitted checkpoint.
 	ErrOldSizeInvalid = errors.New("old size > current")
-	// ErrCheckpointStale is retrned by calls to Update if the oldSize parameter does not match the size of the currently
+	// ErrCheckpointStale is returned by calls to Update if the oldSize parameter does not match the size of the currently
 	// stored checkpoint for the same log.
 	ErrCheckpointStale = errors.New("old size != current")
 	// ErrInvalidProof is returned by calls to Update if the provided consistency proof is invalid.

--- a/internal/witness/witness.go
+++ b/internal/witness/witness.go
@@ -226,7 +226,7 @@ func (w *Witness) Update(ctx context.Context, logID string, nextRaw []byte, cPro
 	if err := proof.VerifyConsistency(logInfo.Hasher, prev.Size, next.Size, cProof, prev.Hash, next.Hash); err != nil {
 		// Complain if the checkpoints aren't consistent.
 		counterInvalidConsistency.Inc(logID)
-		return prevRaw, status.Errorf(codes.FailedPrecondition, "failed to verify consistency proof: %v", err)
+		return prevRaw, status.Errorf(codes.Unauthenticated, "failed to verify consistency proof: %v", err)
 	}
 	// If the consistency proof is good we store the witness cosigned nextRaw.
 	signed, err := w.signChkpt(nextNote)

--- a/internal/witness/witness.go
+++ b/internal/witness/witness.go
@@ -20,6 +20,7 @@ package witness
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -40,6 +41,25 @@ var (
 	counterUpdateSuccess           monitoring.Counter
 	counterInvalidConsistency      monitoring.Counter
 	counterInconsistentCheckpoints monitoring.Counter
+)
+
+var (
+	// ErrNoValidSignature is returned by calls to Update if the provided checkpoint has no valid signature by the expected key.
+	ErrNoValidSignature = errors.New("no valid signatures")
+	// ErrUnknownLog is returned by calls to Update if the provided checkpoint carries an Origin which is unknown to the
+	// witness.
+	ErrUnknownLog = errors.New("unknown log")
+	// ErrOldSizeInvalid is returned by calls to Update if the provided oldSize parameter is larger than the size of the
+	// submitted checkpoint.
+	ErrOldSizeInvalid = errors.New("old size > current")
+	// ErrCheckpointStale is retrned by calls to Update if the oldSize parameter does not match the size of the currently
+	// stored checkpoint for the same log.
+	ErrCheckpointStale = errors.New("old size != current")
+	// ErrInvalidProof is returned by calls to Update if the provided consistency proof is invalid.
+	ErrInvalidProof = errors.New("consistency proof invalid")
+	// ErrRootMismatch is returned by calls to Update if the provided checkpoint is for the same size tree as the currently
+	// stored one, but their root hashes differ.
+	ErrRootMismatch = errors.New("roots do not match")
 )
 
 func initMetrics() {
@@ -101,7 +121,7 @@ func New(wo Opts) (*Witness, error) {
 func (w *Witness) parse(chkptRaw []byte, logID string) (*log.Checkpoint, *note.Note, error) {
 	logInfo, ok := w.Logs[logID]
 	if !ok {
-		return nil, nil, fmt.Errorf("log %q not found", logID)
+		return nil, nil, ErrUnknownLog
 	}
 	cp, _, n, err := log.ParseCheckpoint(chkptRaw, logInfo.Origin, logInfo.SigV)
 	return cp, n, err
@@ -129,26 +149,24 @@ func (w *Witness) GetCheckpoint(logID string) ([]byte, error) {
 // Update updates the latest checkpoint if nextRaw is consistent with the current
 // latest one for this log.
 //
-// It returns the latest cosigned checkpoint held by the witness, which is a signed
-// version of nextRaw if the update was applied.
-//
-// If an error occurs, this method will generally return an error with a status code:
-// - codes.NotFound if the log is unknown
-// - codes.InvalidArgument for general bad requests
-// - codes.AlreadyExists if the checkpoint is smaller than the one the witness knows
-// - codes.FailedPrecondition if the checkpoint is inconsistent with the one the witness knows
-func (w *Witness) Update(ctx context.Context, logID string, nextRaw []byte, cProof [][]byte) ([]byte, error) {
+// It returns the latest cosigned checkpoint held by the witness (which may be the provided checkpoint
+// if it's accepted).
+func (w *Witness) Update(ctx context.Context, logID string, oldSize uint64, nextRaw []byte, cProof [][]byte) ([]byte, error) {
 	// If we don't witness this log then no point in going further.
 	logInfo, ok := w.Logs[logID]
 	if !ok {
-		return nil, status.Errorf(codes.NotFound, "log %q not found", logID)
+		return nil, ErrUnknownLog
 	}
 	counterUpdateAttempt.Inc(logID)
 	// Check the signatures on the raw checkpoint and parse it
 	// into the log.Checkpoint format.
+	//
+	// SPEC: The witness MUST verify the checkpoint signature against the public key(s) it trusts for the
+	//       checkpoint origin, and it MUST ignore signatures from unknown keys.
 	next, nextNote, err := w.parse(nextRaw, logID)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "couldn't parse input checkpoint: %v", err)
+		// TODO(al): Technically this could also be that the checkpoint body is invalid.
+		return nil, ErrNoValidSignature
 	}
 	// Get the latest one for the log because we don't want consistency proofs
 	// with respect to older checkpoints.  Bind this all in a transaction to
@@ -169,56 +187,64 @@ func (w *Witness) Update(ctx context.Context, logID string, nextRaw []byte, cPro
 			// Store a witness cosigned version of the checkpoint.
 			signed, err := w.signChkpt(nextNote)
 			if err != nil {
-				return nil, status.Errorf(codes.Internal, "couldn't sign input checkpoint: %v", err)
+				return nil, fmt.Errorf("couldn't sign input checkpoint: %v", err)
 			}
 
 			if err := write.Set(signed); err != nil {
-				return nil, status.Errorf(codes.Internal, "couldn't set TOFU checkpoint: %v", err)
+				return nil, fmt.Errorf("couldn't set TOFU checkpoint: %v", err)
 			}
 			counterUpdateSuccess.Inc(logID)
 			return signed, nil
 		}
-		return nil, status.Errorf(codes.Internal, "couldn't retrieve latest checkpoint: %v", err)
+		return nil, fmt.Errorf("couldn't retrieve latest checkpoint: %v", err)
 	}
-	// Parse the raw retrieved checkpoint into the log.Checkpoint format.
 	prev, _, err := w.parse(prevRaw, logID)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "couldn't parse stored checkpoint: %v", err)
+		return nil, fmt.Errorf("couldn't parse stored checkpoint: %v", err)
 	}
+
+	// SPEC: The old size MUST be equal to or lower than the (submitted) checkpoint size.
+	if oldSize > next.Size {
+		return prevRaw, ErrOldSizeInvalid
+	}
+	// SPEC: The witness MUST check that the old size matches the size of the latest checkpoint it cosigned
+	//       for the checkpoint's origin (or zero if it never cosigned a checkpoint for that origin)
+	if oldSize != prev.Size {
+		return prevRaw, ErrCheckpointStale
+	}
+	// SPEC: The old size MUST be equal to or lower than the checkpoint size.
 	if next.Size < prev.Size {
-		// Complain if prev is bigger than next.
-		return prevRaw, status.Errorf(codes.AlreadyExists, "cannot prove consistency backwards (%d < %d)", next.Size, prev.Size)
+		return nil, ErrOldSizeInvalid
 	}
+	// SPEC:  If the old size matches the checkpoint size, the witness MUST check that the root hashes are
+	//        also identical.
 	if next.Size == prev.Size {
 		if !bytes.Equal(next.Hash, prev.Hash) {
 			// Code analysis complains about the next line, but it's fine; we've already bailed out
 			// further up the method if the log ID was not found.
 			klog.Errorf("%s: INCONSISTENT CHECKPOINTS!:\n%v\n%v", logID, prev, next) // lgtm [go/log-injection]
 			counterInconsistentCheckpoints.Inc(logID)
-			return prevRaw, status.Errorf(codes.FailedPrecondition, "checkpoint for same size log with differing hash (got %x, have %x)", next.Hash, prev.Hash)
+			return prevRaw, ErrRootMismatch
 		}
 		// This used to short-circuit here to save work.
 		// However, having the most recently witnessed timestamp available is beneficial to demonstrate freshness.
 	}
-	if prev.Size == 0 {
-		// Checkpoints of size 0 are really placeholders and consistency proofs can't be performed.
-		// If we initialized on a tree size of 0, then we simply ratchet forward and effectively TOFU the new checkpoint.
+	// Checkpoints of size 0 are really placeholders and consistency proofs can't be performed.
+	// If we initialized on a tree size of 0, then we simply ratchet forward and effectively TOFU the new checkpoint.
+	if next.Size == 0 {
+		// SPEC:  The proof MUST be empty if the old size is zero.
+		if len(cProof) > 0 {
+			return nil, fmt.Errorf("oldSize=0 but non-zero proof supplied")
+		}
 		signed, err := w.signChkpt(nextNote)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "couldn't sign input checkpoint: %v", err)
+			return nil, fmt.Errorf("couldn't sign input checkpoint: %v", err)
 		}
 		if err := write.Set(signed); err != nil {
-			return nil, status.Errorf(codes.Internal, "couldn't set first non-zero checkpoint: %v", err)
+			return nil, fmt.Errorf("couldn't set first non-zero checkpoint: %v", err)
 		}
 		counterUpdateSuccess.Inc(logID)
 		return signed, nil
-	}
-	if next.Size != prev.Size && len(cProof) == 0 {
-		// We require a proof, but we were given an empty one - the submitter likely thinks we've not seen a checkpoint for this log
-		// before and is trying to get us to TOFU.
-		// This is a special case of "prev > next" above, so return the same code so higher layers can handle similarly (e.g. by telling
-		// the submitter our view of prev.size).
-		return prevRaw, status.Errorf(codes.AlreadyExists, "we already have a non-zero checkpoint")
 	}
 
 	// The only remaining option is next.Size > prev.Size. This might be
@@ -226,15 +252,15 @@ func (w *Witness) Update(ctx context.Context, logID string, nextRaw []byte, cPro
 	if err := proof.VerifyConsistency(logInfo.Hasher, prev.Size, next.Size, cProof, prev.Hash, next.Hash); err != nil {
 		// Complain if the checkpoints aren't consistent.
 		counterInvalidConsistency.Inc(logID)
-		return prevRaw, status.Errorf(codes.Unauthenticated, "failed to verify consistency proof: %v", err)
+		return prevRaw, ErrInvalidProof
 	}
 	// If the consistency proof is good we store the witness cosigned nextRaw.
 	signed, err := w.signChkpt(nextNote)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "couldn't sign input checkpoint: %v", err)
+		return nil, fmt.Errorf("couldn't sign input checkpoint: %v", err)
 	}
 	if err := write.Set(signed); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to store new checkpoint: %v", err)
+		return nil, fmt.Errorf("failed to store new checkpoint: %v", err)
 	}
 	counterUpdateSuccess.Inc(logID)
 	return signed, nil

--- a/omniwitness/omniwitness.go
+++ b/omniwitness/omniwitness.go
@@ -301,6 +301,6 @@ func (w witnessAdapter) GetLatestCheckpoint(ctx context.Context, logID string) (
 	return cp, err
 }
 
-func (w witnessAdapter) Update(ctx context.Context, logID string, newCP []byte, proof [][]byte) ([]byte, error) {
-	return w.w.Update(ctx, logID, newCP, proof)
+func (w witnessAdapter) Update(ctx context.Context, logID string, oldSize uint64, newCP []byte, proof [][]byte) ([]byte, error) {
+	return w.w.Update(ctx, logID, oldSize, newCP, proof)
 }


### PR DESCRIPTION
This PR is a deeper fix to the C2SP `tlog-witness` compliance issues, which changes the internal witness API to better match.

Also removes the call to `Update` exposed via the local HTTP server.

TODO(al): Either in here, or in a follow-up, make `Update` just return the sig rather than the whole CP.