### PR TITLE
[Simplify] Replace {Read,Write}Ops with Update func

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,5 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250227231956-55c901821b1e // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
-github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
-github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
@@ -67,6 +65,7 @@ golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
 golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=
 golang.org/x/time v0.11.0 h1:/bpjEDfN9tkoN/ryeYHnv5hcMlc8ncjMcM4XBk5NWV0=
 golang.org/x/time v0.11.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
+google.golang.org/genproto v0.0.0-20250122153221-138b5a5a4fd4 h1:Pw6WnI9W/LIdRxqK7T6XGugGbHIRl5Q7q3BssH6xk4s=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250227231956-55c901821b1e h1:YA5lmSs3zc/5w+xsRcHqpETkaYyK63ivEPzNTcUUlSA=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250227231956-55c901821b1e/go.mod h1:LuRYeWDFV6WOn90g357N17oMCaxpgCnbi/44qJvDn2I=
 google.golang.org/grpc v1.72.0 h1:S7UkcVa60b5AAQTaO6ZKamFp1zMZSU0fGDK2WZLbBnM=

--- a/internal/persistence/inmemory/inmemory_test.go
+++ b/internal/persistence/inmemory/inmemory_test.go
@@ -22,50 +22,34 @@ import (
 	"github.com/transparency-dev/witness/internal/persistence"
 	ptest "github.com/transparency-dev/witness/internal/persistence/testonly"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"k8s.io/klog/v2"
 )
 
 var nopClose = func() error { return nil }
 
-func TestGetLogs(t *testing.T) {
-	ptest.TestGetLogs(t, func() (persistence.LogStatePersistence, func() error) {
+func TestLogs(t *testing.T) {
+	ptest.TestLogs(t, func() (persistence.LogStatePersistence, func() error) {
 		return NewPersistence(), nopClose
 	})
 }
 
-func TestWriteOps(t *testing.T) {
-	ptest.TestWriteOps(t, func() (persistence.LogStatePersistence, func() error) {
+func TestUpdate(t *testing.T) {
+	ptest.TestUpdate(t, func() (persistence.LogStatePersistence, func() error) {
 		return NewPersistence(), nopClose
 	})
 }
 
-func TestWriteOpsConcurrent(t *testing.T) {
+func TestUpdateConcurrent(t *testing.T) {
 	p := NewPersistence()
 
 	g := errgroup.Group{}
+	logID := "foo"
 
 	for i := 0; i < 25; i++ {
 		i := i
 		g.Go(func() error {
-			w, err := p.WriteOps("foo")
-			if err != nil {
-				return fmt.Errorf("WriteOps %d: %v", i, err)
-			}
-			defer func() {
-				if err := w.Close(); err != nil {
-					klog.Errorf("Failed to close log state write ops: %v", err)
-				}
-			}()
-			if _, err := w.GetLatest(); err != nil {
-				if status.Code(err) != codes.NotFound {
-					return fmt.Errorf("GetLatest %d: %v", i, err)
-				}
-			}
-			// Ignore any error on Set because we expect some.
-			_ = w.Set([]byte(fmt.Sprintf("success %d", i)))
-			return nil
+			return p.Update(logID, func(current []byte) (next []byte, err error) {
+				return []byte(fmt.Sprintf("success %d", i)), nil
+			})
 		})
 	}
 
@@ -73,11 +57,7 @@ func TestWriteOpsConcurrent(t *testing.T) {
 		t.Error(err)
 	}
 
-	r, err := p.ReadOps("foo")
-	if err != nil {
-		t.Fatal(err)
-	}
-	cp, err := r.GetLatest()
+	cp, err := p.Latest(logID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -37,7 +37,7 @@ type LogStatePersistence interface {
 	// should return the serialised form of the updated checkpoint, or an
 	// error.
 	//
-	// There is no requirement that the provuided ID is present in Logs(); if
+	// There is no requirement that the provided ID is present in Logs(); if
 	// the ID is not there, and this operation succeeds in committing
 	// a checkpoint, then Logs() will return the new ID afterwards.
 	Update(logID string, f UpdateFn) error

--- a/internal/persistence/sql/sql.go
+++ b/internal/persistence/sql/sql.go
@@ -71,7 +71,6 @@ func (p *sqlLogPersistence) Logs() ([]string, error) {
 
 func (p *sqlLogPersistence) Latest(logID string) ([]byte, error) {
 	return getLatestCheckpoint(p.db.QueryRow, logID)
-
 }
 
 func (p *sqlLogPersistence) Update(logID string, f persistence.UpdateFn) error {

--- a/internal/persistence/sql/sql.go
+++ b/internal/persistence/sql/sql.go
@@ -88,6 +88,7 @@ func (p *sqlLogPersistence) Update(logID string, f persistence.UpdateFn) error {
 	if err != nil {
 		return err
 	}
+
 	updated, err := f(current)
 	if err != nil {
 		return err

--- a/internal/persistence/sql/sql_test.go
+++ b/internal/persistence/sql/sql_test.go
@@ -24,15 +24,15 @@ import (
 	ptest "github.com/transparency-dev/witness/internal/persistence/testonly"
 )
 
-func TestGetLogs(t *testing.T) {
-	ptest.TestGetLogs(t, func() (persistence.LogStatePersistence, func() error) {
+func TestLogs(t *testing.T) {
+	ptest.TestLogs(t, func() (persistence.LogStatePersistence, func() error) {
 		db, close := mustCreateDB(t)
 		return NewPersistence(db), close
 	})
 }
 
-func TestWriteOps(t *testing.T) {
-	ptest.TestWriteOps(t, func() (persistence.LogStatePersistence, func() error) {
+func TestUpdate(t *testing.T) {
+	ptest.TestUpdate(t, func() (persistence.LogStatePersistence, func() error) {
 		db, close := mustCreateDB(t)
 		return NewPersistence(db), close
 	})

--- a/internal/witness/witness_test.go
+++ b/internal/witness/witness_test.go
@@ -218,7 +218,7 @@ func TestGetChkpt(t *testing.T) {
 			}
 			// Try to get the latest checkpoint.
 			cosigned, err := w.GetCheckpoint(test.queryID)
-			if !test.wantThere && err == nil {
+			if !test.wantThere && err == nil && cosigned != nil {
 				t.Fatalf("returned a checkpoint but shouldn't have")
 			}
 			// If we got something then verify it under the log and
@@ -300,11 +300,11 @@ func TestUpdate(t *testing.T) {
 			// Proof should be empty.
 			isGood: false,
 		}, {
-			desc:      "vanilla consistency starting from tree size 0 without proof",
-			initC:     mustCreateCheckpoint(t, mSK, 0, rfc6962.DefaultHasher.EmptyRoot()),
-			oldSize:   0,
-			newC:      mustCreateCheckpoint(t, mSK, 5, dh("e35b268c1522014ef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),
-			wantError: ErrInvalidProof,
+			desc:    "vanilla consistency starting from tree size 0 without proof",
+			initC:   mustCreateCheckpoint(t, mSK, 0, rfc6962.DefaultHasher.EmptyRoot()),
+			oldSize: 0,
+			newC:    mustCreateCheckpoint(t, mSK, 5, dh("e35b268c1522014ef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),
+			isGood:  true,
 		}, {
 			desc:    "vanilla resubmit known CP",
 			initC:   mustCreateCheckpoint(t, mSK, 5, dh("e35b268c1522014ef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),


### PR DESCRIPTION
This PR replaces the `ReadOps`/`WriteOps` structures with `Latest` and `Update`.

The `.*Ops` approach exposes the transaction to higher levels, which is a richer interface than is strictly needed.

Towards #355