### PR TITLE
Remove unnecessary named func type

### DIFF
--- a/internal/persistence/inmemory/inmemory.go
+++ b/internal/persistence/inmemory/inmemory.go
@@ -55,7 +55,7 @@ func (p *inMemoryPersistence) Latest(logID string) ([]byte, error) {
 	return p.checkpoints[logID], nil
 }
 
-func (p *inMemoryPersistence) Update(logID string, f persistence.UpdateFn) error {
+func (p *inMemoryPersistence) Update(logID string, f func([]byte) ([]byte, error)) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	u, err := f(p.checkpoints[logID])

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -40,12 +40,5 @@ type LogStatePersistence interface {
 	// There is no requirement that the provided ID is present in Logs(); if
 	// the ID is not there, and this operation succeeds in committing
 	// a checkpoint, then Logs() will return the new ID afterwards.
-	Update(logID string, f UpdateFn) error
+	Update(logID string, f func([]byte) ([]byte, error)) error
 }
-
-// UpdateFn is the signature of a function which takes the currently stored
-// checkpoint and returns a newer version which should replace it.
-//
-// Implementations should interpret a nil argument as meaning there is no
-// currently stored checkpoint.
-type UpdateFn func(current []byte) (next []byte, err error)

--- a/internal/persistence/sql/sql.go
+++ b/internal/persistence/sql/sql.go
@@ -73,7 +73,7 @@ func (p *sqlLogPersistence) Latest(logID string) ([]byte, error) {
 	return getLatestCheckpoint(p.db.QueryRow, logID)
 }
 
-func (p *sqlLogPersistence) Update(logID string, f persistence.UpdateFn) error {
+func (p *sqlLogPersistence) Update(logID string, f func([]byte) ([]byte, error)) error {
 	tx, err := p.db.Begin()
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR removes a named type and inlines the definition where it was used.

The named type is currently making it impossible to update the AW implementation, and didn't really provide much value as the signature is small enough to inline easily.

Removing it avoids the needing to resolve opaque indirection when implementing it, and the need to type alias it into the `omniwitness` package.