### PR TITLE
Rename Rekor feeder, remove fetching stable checkpoint

### DIFF
--- a/internal/feeder/rekor_v1/rekor_feeder.go
+++ b/internal/feeder/rekor_v1/rekor_feeder.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package rekor is an implementation of a witness feeder for the Sigstore log: Rekór.
-package rekor
+package rekor_v1
 
 import (
 	"context"
@@ -80,7 +80,7 @@ func FeedLog(ctx context.Context, l config.Log, update feeder.UpdateFn, c *http.
 		// Each Rekor feeder will request the same log info.
 		// TODO: Explore if it's feasible to request this once for all Rekor feeders.
 		li := logInfo{}
-		if err := getJSON(ctx, c, lURL, "api/v1/log?stable=true", &li); err != nil {
+		if err := getJSON(ctx, c, lURL, "api/v1/log", &li); err != nil {
 			return nil, fmt.Errorf("failed to fetch log info: %v", err)
 		}
 		// Active shard

--- a/omniwitness/omniwitness.go
+++ b/omniwitness/omniwitness.go
@@ -41,7 +41,7 @@ import (
 	"github.com/transparency-dev/witness/internal/bastion"
 	"github.com/transparency-dev/witness/internal/distribute/rest"
 	"github.com/transparency-dev/witness/internal/feeder/pixelbt"
-	"github.com/transparency-dev/witness/internal/feeder/rekor"
+	"github.com/transparency-dev/witness/internal/feeder/rekor_v1"
 	"github.com/transparency-dev/witness/internal/feeder/serverless"
 	"github.com/transparency-dev/witness/internal/feeder/sumdb"
 	"github.com/transparency-dev/witness/internal/feeder/tiles"
@@ -270,7 +270,7 @@ func (f Feeder) FeedFunc() logFeeder {
 	case Pixel:
 		return pixelbt.FeedLog
 	case Rekor:
-		return rekor.FeedLog
+		return rekor_v1.FeedLog
 	case Tiles:
 		return tiles.FeedLog
 	}


### PR DESCRIPTION
Renaming this feeder to distinguish between this feeder and the upcoming Rekor v2 feeder which will simply use the tiles feeder.

Also remove fetching the stable checkpoint, since this has never actually been integrated into any workflow in practice.