### PR TITLE
Drop support for legacy witness sigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# transparency-dev/witness Changelog
+
+## HEAD
+
+* Witness binary emits only `cosignature/v1` signature.
+

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 This repository contains libraries and binaries for running witnesses.
 A witness verifies that logs are evolving in an append-only manner and counter-signs checkpoints that represent an append-only evolution from any previously witnessed checkpoints.
 These witnessed checkpoints can be consumed by clients that want protection against split-views.
+The signature format used is [`cosignature/v1`](https://C2SP.org/tlog-cosignature@v1.0.0-rc.1).
 
 Users wishing to run this should start with the [OmniWitness](./cmd/omniwitness/).
 

--- a/cmd/omniwitness/monolith.go
+++ b/cmd/omniwitness/monolith.go
@@ -105,17 +105,13 @@ func main() {
 		}
 	}
 
-	signerLegacy, err := note.NewSigner(*signingKey)
-	if err != nil {
-		klog.Exitf("Failed to init signer v0: %v", err)
-	}
 	signerCosigV1, err := f_note.NewSignerForCosignatureV1(*signingKey)
 	if err != nil {
 		klog.Exitf("Failed to init signer v1: %v", err)
 	}
 
 	opConfig := omniwitness.OperatorConfig{
-		WitnessKeys:            []note.Signer{signerLegacy, signerCosigV1},
+		WitnessKeys:            []note.Signer{signerCosigV1},
 		WitnessVerifier:        signerCosigV1.Verifier(),
 		RestDistributorBaseURL: *restDistributorBaseURL,
 		BastionAddr:            *bastionAddr,


### PR DESCRIPTION
With a cosignature/v2 spec on the horizon (https://github.com/C2SP/C2SP/pull/146/), I'm cleaning out the old legacy signatures. I can't see any users of these any more.

Added a CHANGELOG; we should probably tag a 1.0.0 of this repo soon.
