### PR TITLE
Pass Context to persistence layer.

### DIFF
--- a/internal/persistence/inmemory/inmemory.go
+++ b/internal/persistence/inmemory/inmemory.go
@@ -16,6 +16,7 @@
 package inmemory
 
 import (
+	"context"
 	"sync"
 
 	"github.com/transparency-dev/witness/internal/persistence"
@@ -35,11 +36,11 @@ type inMemoryPersistence struct {
 	checkpoints map[string][]byte
 }
 
-func (p *inMemoryPersistence) Init() error {
+func (p *inMemoryPersistence) Init(_ context.Context) error {
 	return nil
 }
 
-func (p *inMemoryPersistence) Logs() ([]string, error) {
+func (p *inMemoryPersistence) Logs(_ context.Context) ([]string, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	res := make([]string, 0, len(p.checkpoints))
@@ -49,13 +50,13 @@ func (p *inMemoryPersistence) Logs() ([]string, error) {
 	return res, nil
 }
 
-func (p *inMemoryPersistence) Latest(logID string) ([]byte, error) {
+func (p *inMemoryPersistence) Latest(_ context.Context, logID string) ([]byte, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return p.checkpoints[logID], nil
 }
 
-func (p *inMemoryPersistence) Update(logID string, f func([]byte) ([]byte, error)) error {
+func (p *inMemoryPersistence) Update(_ context.Context, logID string, f func([]byte) ([]byte, error)) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	u, err := f(p.checkpoints[logID])

--- a/internal/persistence/inmemory/inmemory_test.go
+++ b/internal/persistence/inmemory/inmemory_test.go
@@ -47,7 +47,7 @@ func TestUpdateConcurrent(t *testing.T) {
 	for i := 0; i < 25; i++ {
 		i := i
 		g.Go(func() error {
-			return p.Update(logID, func(current []byte) (next []byte, err error) {
+			return p.Update(t.Context(), logID, func(current []byte) (next []byte, err error) {
 				return []byte(fmt.Sprintf("success %d", i)), nil
 			})
 		})
@@ -57,7 +57,7 @@ func TestUpdateConcurrent(t *testing.T) {
 		t.Error(err)
 	}
 
-	cp, err := p.Latest(logID)
+	cp, err := p.Latest(t.Context(), logID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -15,19 +15,21 @@
 // Package persistence defines interfaces and tests for storing log state.
 package persistence
 
+import "context"
+
 // LogStatePersistence is a handle on persistent storage for log state.
 type LogStatePersistence interface {
 	// Init sets up the persistence layer. This should be idempotent,
 	// and will be called once per process startup.
-	Init() error
+	Init(context.Context) error
 
 	// Logs returns the IDs of all logs that have checkpoints that can
 	// be read.
-	Logs() ([]string, error)
+	Logs(context.Context) ([]string, error)
 
 	// Latest returns the latest checkpoint.
 	// If no checkpoint exists, it must return nil.
-	Latest(logID string) ([]byte, error)
+	Latest(ctx context.Context, logID string) ([]byte, error)
 
 	// Update allows for atomically updating the currently stored (if any)
 	// checkpoint for the given logID.
@@ -40,5 +42,5 @@ type LogStatePersistence interface {
 	// There is no requirement that the provided ID is present in Logs(); if
 	// the ID is not there, and this operation succeeds in committing
 	// a checkpoint, then Logs() will return the new ID afterwards.
-	Update(logID string, f func([]byte) ([]byte, error)) error
+	Update(ctx context.Context, logID string, f func([]byte) ([]byte, error)) error
 }

--- a/internal/persistence/sql/sql.go
+++ b/internal/persistence/sql/sql.go
@@ -16,6 +16,7 @@
 package sql
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 
@@ -34,7 +35,7 @@ type sqlLogPersistence struct {
 	db *sql.DB
 }
 
-func (p *sqlLogPersistence) Init() error {
+func (p *sqlLogPersistence) Init(_ context.Context) error {
 	_, err := p.db.Exec(`CREATE TABLE IF NOT EXISTS chkpts (
 		logID BLOB PRIMARY KEY,
 		chkpt BLOB
@@ -42,7 +43,7 @@ func (p *sqlLogPersistence) Init() error {
 	return err
 }
 
-func (p *sqlLogPersistence) Logs() ([]string, error) {
+func (p *sqlLogPersistence) Logs(_ context.Context) ([]string, error) {
 	rows, err := p.db.Query("SELECT logID FROM chkpts")
 	if err != nil {
 		return nil, err
@@ -68,11 +69,11 @@ func (p *sqlLogPersistence) Logs() ([]string, error) {
 	return logs, nil
 }
 
-func (p *sqlLogPersistence) Latest(logID string) ([]byte, error) {
+func (p *sqlLogPersistence) Latest(_ context.Context, logID string) ([]byte, error) {
 	return getLatestCheckpoint(p.db.QueryRow, logID)
 }
 
-func (p *sqlLogPersistence) Update(logID string, f func([]byte) ([]byte, error)) error {
+func (p *sqlLogPersistence) Update(_ context.Context, logID string, f func([]byte) ([]byte, error)) error {
 	tx, err := p.db.Begin()
 	if err != nil {
 		return err

--- a/internal/witness/witness_test.go
+++ b/internal/witness/witness_test.go
@@ -83,7 +83,7 @@ func newWitness(t *testing.T, logs []logOpts) *Witness {
 		KnownLogs:   logMap,
 	}
 	// Create the witness
-	w, err := New(opts)
+	w, err := New(t.Context(), opts)
 	if err != nil {
 		t.Fatalf("couldn't create witness: %v", err)
 	}

--- a/omniwitness/omniwitness.go
+++ b/omniwitness/omniwitness.go
@@ -117,7 +117,7 @@ func Main(ctx context.Context, operatorConfig OperatorConfig, p LogStatePersiste
 	if err != nil {
 		return fmt.Errorf("failed to convert witness config to map: %v", err)
 	}
-	witness, err := witness.New(witness.Opts{
+	witness, err := witness.New(ctx, witness.Opts{
 		Persistence: p,
 		Signers:     operatorConfig.WitnessKeys,
 		KnownLogs:   knownLogs,


### PR DESCRIPTION
This PR updates the persistence interface and implementations to pass through `context.Context`.

Some storage implementations will likely require passing context through, particularly those which store data externally to the omniwitness process. This PR will enable such storage implementation to be built.

Towards #386 