### PR TITLE
Fix Spanner bug preventing recovery from stale size

### DIFF
--- a/cmd/gcp/omniwitness/persistence.go
+++ b/cmd/gcp/omniwitness/persistence.go
@@ -114,7 +114,7 @@ func (p *spannerPersistence) Update(ctx context.Context, logID string, f func([]
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed to update: %v", err)
+		return fmt.Errorf("failed to update: %w", err)
 	}
 
 	return nil

--- a/internal/feeder/feeder.go
+++ b/internal/feeder/feeder.go
@@ -155,7 +155,7 @@ func (f *feeder) submitToWitness(ctx context.Context, cpRaw []byte, cpSubmit log
 			f.oldSize = actualSize
 			return nil, backoff.RetryAfter(1)
 		case err != nil:
-			e := fmt.Errorf("failed to submit checkpoint to witness: %v", err)
+			e := fmt.Errorf("%q: failed to submit checkpoint to witness: %v", cpSubmit.Origin, err)
 			klog.Warning(e.Error())
 			return nil, e
 		default:

--- a/internal/witness/witness.go
+++ b/internal/witness/witness.go
@@ -200,7 +200,7 @@ func (w *Witness) Update(ctx context.Context, oldSize uint64, nextRaw []byte, cP
 		//       for the checkpoint's origin (or zero if it never cosigned a checkpoint for that origin)
 		if oldSize != prev.Size {
 			retSize, retSigs = prev.Size, nil
-			return nil, ErrCheckpointStale
+			return nil, fmt.Errorf("%w (%d != %d)", ErrCheckpointStale, oldSize, prev.Size)
 		}
 		// SPEC: The old size MUST be equal to or lower than the checkpoint size.
 		if next.Size < prev.Size {


### PR DESCRIPTION
This PR fixes a bug in the Spanner persistence implementation where underlying error types were being lost rather then wrapped.

This caused higher levels to be confused about what course of action to take in order to rectify the issue.

Added a test to catch this if it happens again, and augmented the particular error message we were seeing to provide a bit more info.