### PR TITLE
Update POST path to match spec

### DIFF
--- a/api/http.go
+++ b/api/http.go
@@ -16,7 +16,7 @@
 package api
 
 const (
-	// HTTPUpdate is the path of the URL to update to a new checkpoint.
+	// HTTPAddCheckpoint is the path of the URL to update to a new checkpoint.
 	// This endpoint expects a https://c2sp.org/tlog-witness compliant request.
-	HTTPUpdate = "/"
+	HTTPAddCheckpoint = "/add-checkpoint"
 )


### PR DESCRIPTION
The [tlog-witness spec](https://github.com/C2SP/C2SP/blob/main/tlog-witness.md#add-checkpoint) says POSTs should be taken on `<prefix>/add-checkpoint`. This PR updates the omniwitness to match.