### PR TITLE
Hide configuration implementation

### DIFF
--- a/internal/bastion/bastion.go
+++ b/internal/bastion/bastion.go
@@ -30,7 +30,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/transparency-dev/witness/internal/config"
 	"github.com/transparency-dev/witness/monitoring"
 	"golang.org/x/mod/sumdb/note"
 	"golang.org/x/net/http2"
@@ -40,7 +39,6 @@ import (
 type Config struct {
 	Addr            string
 	Prefix          string
-	Logs            []config.Log
 	BastionKey      ed25519.PrivateKey
 	WitnessVerifier note.Verifier
 }

--- a/internal/config/log.go
+++ b/internal/config/log.go
@@ -18,25 +18,8 @@
 package config
 
 import (
-	"github.com/transparency-dev/formats/log"
-	f_note "github.com/transparency-dev/formats/note"
 	"golang.org/x/mod/sumdb/note"
 )
-
-// NewLog creates a Log from the given origin, public key & type, and URL.
-func NewLog(origin, pk, url string) (Log, error) {
-	id := log.ID(origin)
-	logV, err := f_note.NewVerifier(pk)
-	if err != nil {
-		return Log{}, err
-	}
-	return Log{
-		ID:       id,
-		Origin:   origin,
-		Verifier: logV,
-		URL:      url,
-	}, nil
-}
 
 // Log describes a verifiable log.
 type Log struct {

--- a/internal/distribute/rest/distribute.go
+++ b/internal/distribute/rest/distribute.go
@@ -60,7 +60,10 @@ func initMetrics() {
 	})
 }
 
+// LogConfig describes the API contract of a source of logs to be distributed.
 type LogConfig interface {
+	// Logs should return the _current_ set of logs whose checkpoints should be distributed.
+	// This may be called repeatedly by the implementation in order to ensure that changes to the underlying config are reflected in the distribution operation.
 	Logs() iter.Seq[config.Log]
 }
 

--- a/omniwitness/configs_test.go
+++ b/omniwitness/configs_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/transparency-dev/witness/omniwitness"
-	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -32,25 +31,30 @@ var (
 
 func testConfig(t *testing.T, cfg []byte) {
 	t.Helper()
-	logCfg := omniwitness.LogConfig{}
-	if err := yaml.Unmarshal(cfg, &logCfg); err != nil {
+	logCfg, err := omniwitness.NewStaticLogConfig(cfg)
+	if err != nil {
 		t.Fatal("failed to unmarshal config", err)
 	}
-	if len(logCfg.Logs) == 0 {
-		t.Fatal("no logs defined in config")
-	}
-	for _, l := range logCfg.Logs {
-		if l.Feeder == 0 {
-			t.Errorf("log %q has unknown feeder", l.Origin)
-		}
+	c := 0
+	for l := range logCfg.Logs() {
+		c++
 		if len(l.URL) == 0 {
 			t.Errorf("log %q has no URL", l.URL)
+		}
+	}
+	if c == 0 {
+		t.Fatal("no logs defined in config")
+	}
+
+	for f, l := range logCfg.Feeders() {
+		if f == omniwitness.None {
+			t.Errorf("log %q has unknown feeder", l.Origin)
 		}
 	}
 }
 
 func TestProdConfig(t *testing.T) {
-	testConfig(t, omniwitness.ConfigLogs)
+	testConfig(t, omniwitness.DefaultConfigLogs)
 }
 
 func TestConfig(t *testing.T) {

--- a/omniwitness/http.go
+++ b/omniwitness/http.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 
 	"github.com/transparency-dev/formats/log"
-	"github.com/transparency-dev/witness/internal/config"
 	"github.com/transparency-dev/witness/internal/witness"
 	"github.com/transparency-dev/witness/monitoring"
 	"golang.org/x/mod/sumdb/note"
@@ -59,7 +58,7 @@ func initMetrics() {
 // httpHandler knows how to handle tlog-witness HTTP requests.
 type httpHandler struct {
 	update      func(ctx context.Context, oldSize uint64, newCP []byte, proof [][]byte) ([]byte, uint64, error)
-	logs        map[string]config.Log
+	logs        LogConfig
 	witVerifier note.Verifier
 	limiter     *rate.Limiter
 }
@@ -94,7 +93,7 @@ func (a *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	logID := log.ID(s[0])
-	logCfg, ok := a.logs[logID]
+	logCfg, ok := a.logs.Log(logID)
 	if !ok {
 		klog.V(1).Infof("unknown log: %v", logID)
 		w.WriteHeader(http.StatusNotFound)

--- a/omniwitness/http_test.go
+++ b/omniwitness/http_test.go
@@ -95,9 +95,10 @@ func TestHandler(t *testing.T) {
 		t.Fatalf("NewVerifier: %v", err)
 	}
 	logID := log.ID(testCPOrigin)
-	logs := map[string]config.Log{
-		logID: config.Log{Origin: testCPOrigin},
-	}
+	logs := &staticLogConfig{
+		logs: map[string]parsedLog{
+			logID: parsedLog{Config: config.Log{Origin: testCPOrigin}},
+		}}
 	for _, test := range []struct {
 		name string
 		// fake witness control


### PR DESCRIPTION
This PR:
1. shifts configuration to be done mostly in terms of `config.Log` structs rather than a number of similar types in various packages.
2. hides the implementation of the configuration delivery mechanism from the things which ultimately interrogate/use that config.

This opens a path to allowing binaries using the library to store their configuration in whichever way makes most sense for them.