### PR TITLE
Use a limited number of workers for feeding

### DIFF
--- a/cmd/gcp/omniwitness/main.go
+++ b/cmd/gcp/omniwitness/main.go
@@ -37,7 +37,8 @@ var (
 	signerPrivateKeySecretName = flag.String("signer_private_key_secret_name", "", "Private key secret name for witnes signatures. Format: projects/{projectId}/secrets/{secretName}/versions/{secretVersion}.")
 	httpTimeout                = flag.Duration("http_timeout", 10*time.Second, "HTTP timeout for outbound requests.")
 
-	pollInterval = flag.Duration("poll_interval", 1*time.Minute, "Time to wait between polling logs for new checkpoints. Set to 0 to disable polling logs.")
+	pollInterval      = flag.Duration("poll_interval", 1*time.Minute, "Time to wait between polling logs for new checkpoints. Set to 0 to disable polling logs.")
+	feederConcurrency = flag.Uint("feeder_concurrency", 1, "Maximum number of concurrent feeder tasks")
 )
 
 func main() {
@@ -69,10 +70,11 @@ func main() {
 	}
 
 	opConfig := omniwitness.OperatorConfig{
-		WitnessKeys:     []note.Signer{signer},
-		WitnessVerifier: signer.Verifier(),
-		FeedInterval:    *pollInterval,
-		ServeMux:        mux,
+		WitnessKeys:      []note.Signer{signer},
+		WitnessVerifier:  signer.Verifier(),
+		FeedInterval:     *pollInterval,
+		NumFeederWorkers: *feederConcurrency,
+		ServeMux:         mux,
 	}
 	p, shutdown, err := newSpannerPersistence(ctx, *spannerURI)
 	if err != nil {

--- a/cmd/omniwitness/monolith.go
+++ b/cmd/omniwitness/monolith.go
@@ -55,7 +55,8 @@ var (
 	rateLimit              = flag.Float64("rate_limit", 0, "Maximum number of update requests per second to serve, or zero to disable")
 	httpTimeout            = flag.Duration("http_timeout", 10*time.Second, "HTTP timeout for outbound requests")
 
-	pollInterval = flag.Duration("poll_interval", 1*time.Minute, "Time to wait between polling logs for new checkpoints. Set to 0 to disable polling logs.")
+	pollInterval      = flag.Duration("poll_interval", 1*time.Minute, "Time to wait between polling logs for new checkpoints. Set to 0 to disable polling logs.")
+	feederConcurrency = flag.Uint("feeder_concurrency", 1, "Maximum number of concurrent feeder tasks")
 )
 
 func main() {
@@ -118,6 +119,7 @@ func main() {
 		BastionKey:             bastionKey,
 		RateLimit:              *rateLimit,
 		FeedInterval:           *pollInterval,
+		NumFeederWorkers:       *feederConcurrency,
 	}
 	var p persistence.LogStatePersistence
 	if len(*dbFile) > 0 {

--- a/omniwitness/omniwitness.go
+++ b/omniwitness/omniwitness.go
@@ -23,7 +23,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"iter"
-	"math/rand/v2"
 	"net"
 	"net/http"
 	"strings"
@@ -87,6 +86,9 @@ type OperatorConfig struct {
 	// Logs provides the witness with the log configuration.
 	// If unset, uses the embedded default config.
 	Logs LogConfig
+
+	// NumFeederWorkers specifies the number of concurrent workers doing feeder work to the witness.
+	NumFeederWorkers uint
 }
 
 // LogConfig is the contract of something which knows how to provide log configuration info for the witness.
@@ -155,20 +157,51 @@ func Main(ctx context.Context, operatorConfig OperatorConfig, p LogStatePersiste
 	}
 
 	if operatorConfig.FeedInterval > 0 {
-		for f, l := range operatorConfig.Logs.Feeders() {
-			if f != None {
-				// Continually feed this log in its own goroutine, hooked up to the global waitgroup.
-				g.Go(func() error {
-					spreadDelay := time.Duration(rand.Int64N(int64(operatorConfig.FeedInterval)))
-					klog.Infof("Feeder %q goroutine will start after spread delay of %s", l.Origin, spreadDelay)
-					defer klog.Infof("Feeder %q goroutine done", l.Origin)
-
-					time.Sleep(spreadDelay)
-					klog.Infof("Feeder %q running", l.Origin)
-					return f.FeedFunc()(ctx, l, witness.Update, httpClient, operatorConfig.FeedInterval)
-				})
-			}
+		// Must have at least one worker if feeding is enabled.
+		if operatorConfig.NumFeederWorkers == 0 {
+			operatorConfig.NumFeederWorkers = 1
 		}
+
+		feedWork := make(chan func() error, operatorConfig.NumFeederWorkers)
+
+		klog.Infof("Starting %d feeder worker(s)", operatorConfig.NumFeederWorkers)
+		for range operatorConfig.NumFeederWorkers {
+			g.Go(func() error {
+				for {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case f := <-feedWork:
+						if err := f(); err != nil {
+							// Log this, but don't return the error as we want to continue
+							// executing feeder jobs until the context is done.
+							klog.Infof("Feed job failed: %v", err)
+						}
+					}
+				}
+			})
+		}
+
+		// Send feeder work to workers
+		g.Go(func() error {
+			klog.Infof("Starting feeder jobs")
+			for {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(operatorConfig.FeedInterval):
+				}
+
+				for f, l := range operatorConfig.Logs.Feeders() {
+					if f != None {
+						klog.Infof("Request to feed %s", l.Origin)
+						feedWork <- func() error {
+							return f.FeedFunc()(ctx, l, witness.Update, httpClient, 0 /* zero interval == run once and return */)
+						}
+					}
+				}
+			}
+		})
 	}
 	operatorConfig.ServeMux.Handle(api.HTTPAddCheckpoint, http.MaxBytesHandler(handler, 16*1024))
 


### PR DESCRIPTION
This PR changes the strategy for feeding logs to use a worker/jobs approach, allowing the operator to limit the number of concurrent feeders.