### PR TITLE
Improve feeders

### DIFF
--- a/cmd/feedwitness/main.go
+++ b/cmd/feedwitness/main.go
@@ -50,7 +50,6 @@ var (
 	witnessURL    multiStringFlag
 	httpsInsecure = flag.Bool("https_insecure", false, "Set to true to disable TLS verification of the witness service")
 	feed          = flag.String("feed", ".*", "RegEx matching log origins to feed checkpoints from")
-	loopInterval  = flag.Duration("loop_interval", 0, "If set to > 0, runs in looping mode sleeping this duration between feed attempts")
 	rateLimit     = flag.Float64("max_qps", 2, "Defines maximum number of requests/s to send per witness")
 	metricsAddr   = flag.String("metrics_listen", ":8081", "Address to listen on for metrics")
 )

--- a/internal/feeder/feeder.go
+++ b/internal/feeder/feeder.go
@@ -120,7 +120,7 @@ func (f *feeder) feedOnce(ctx context.Context) ([]byte, error) {
 
 	wCP, err := f.submitToWitness(ctx, cp, *cpSubmit, f.opts)
 	if err != nil {
-		return nil, fmt.Errorf("witness submission failed: %v", err)
+		return nil, fmt.Errorf("witness submission failed: %w", err)
 	}
 	return wCP, nil
 }
@@ -142,8 +142,7 @@ func (f *feeder) submitToWitness(ctx context.Context, cpRaw []byte, cpSubmit log
 		// try to build one, even if the witness doesn't have a "latest" checkpoint for this log.
 		conP, err = opts.FetchProof(ctx, f.oldSize, cpSubmit)
 		if err != nil {
-			e := fmt.Errorf("failed to fetch consistency proof: %v", err)
-			klog.Warning(e.Error())
+			e := fmt.Errorf("failed to fetch consistency proof: %w", err)
 			return nil, backoff.Permanent(e)
 		}
 		klog.V(2).Infof("%q: Fetched proof %d -> %d: %x", cpSubmit.Origin, f.oldSize, cpSubmit.Size, conP)
@@ -155,8 +154,7 @@ func (f *feeder) submitToWitness(ctx context.Context, cpRaw []byte, cpSubmit log
 			f.oldSize = actualSize
 			return nil, backoff.RetryAfter(1)
 		case err != nil:
-			e := fmt.Errorf("%q: failed to submit checkpoint to witness: %v", cpSubmit.Origin, err)
-			klog.Warning(e.Error())
+			e := fmt.Errorf("%q: failed to submit checkpoint to witness: %w", cpSubmit.Origin, err)
 			return nil, backoff.Permanent(e)
 		default:
 			if f.oldSize == cpSubmit.Size {

--- a/internal/feeder/feeder.go
+++ b/internal/feeder/feeder.go
@@ -61,6 +61,10 @@ type FeedOpts struct {
 	Update UpdateFn
 }
 
+// FeedOnce completes one feeding operation for the log and witness in the provided configuration.
+// The provided sizeHint is size of the log that the caller believes is current on the target witness.
+//
+// Returns a new hint on what the current size of the log on the target witness.
 func FeedOnce(ctx context.Context, sizeHint uint64, opts FeedOpts) (uint64, error) {
 	cp, err := opts.FetchCheckpoint(ctx)
 	if err != nil {

--- a/internal/feeder/feeder_test.go
+++ b/internal/feeder/feeder_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/transparency-dev/merkle/rfc6962"
 	sclient "github.com/transparency-dev/serverless-log/client"
 	"github.com/transparency-dev/serverless-log/testdata"
+	"github.com/transparency-dev/witness/internal/witness"
 	"golang.org/x/mod/sumdb/note"
 )
 
@@ -88,7 +89,7 @@ func TestFeedOnce(t *testing.T) {
 			Update:          test.update,
 		}
 		t.Run(test.desc, func(t *testing.T) {
-			_, err := FeedOnce(ctx, opts)
+			_, err := FeedOnce(ctx, 0, opts)
 			gotErr := err != nil
 			if test.wantErr != gotErr {
 				t.Fatalf("Got err %v, want err %t", err, test.wantErr)
@@ -105,7 +106,7 @@ type slowWitness struct {
 func (sw *slowWitness) Update(_ context.Context, oldSize uint64, newCP []byte, proof [][]byte) ([]byte, uint64, error) {
 	if sw.times > 0 {
 		sw.times = sw.times - 1
-		return nil, 0, fmt.Errorf("will fail for %d more calls", sw.times)
+		return nil, oldSize, fmt.Errorf("will fail for %d more calls (%w)", sw.times, witness.ErrCheckpointStale)
 	}
 	sw.latestCP = newCP
 

--- a/internal/feeder/serverless/serverless_feeder.go
+++ b/internal/feeder/serverless/serverless_feeder.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"time"
 
 	"github.com/transparency-dev/formats/log"
 	"github.com/transparency-dev/merkle/rfc6962"
@@ -34,10 +33,10 @@ import (
 
 // FeedLog periodically feeds checkpoints from the log to the witness.
 // This function returns once the provided context is done.
-func FeedLog(ctx context.Context, l config.Log, update feeder.UpdateFn, c *http.Client, interval time.Duration) error {
+func FeedLog(ctx context.Context, l config.Log, sizeHint uint64, update feeder.UpdateFn, c *http.Client) (uint64, error) {
 	lURL, err := url.Parse(l.URL)
 	if err != nil {
-		return fmt.Errorf("invalid LogURL %q: %v", l.URL, err)
+		return sizeHint, fmt.Errorf("invalid LogURL %q: %v", l.URL, err)
 	}
 	f := newFetcher(c, lURL)
 	h := rfc6962.DefaultHasher
@@ -66,11 +65,8 @@ func FeedLog(ctx context.Context, l config.Log, update feeder.UpdateFn, c *http.
 		LogSigVerifier:  l.Verifier,
 		Update:          update,
 	}
-	if interval > 0 {
-		return feeder.Run(ctx, interval, opts)
-	}
-	_, err = feeder.FeedOnce(ctx, opts)
-	return err
+	newSize, err := feeder.FeedOnce(ctx, sizeHint, opts)
+	return newSize, err
 }
 
 // TODO(al): factor this stuff out and share between tools:

--- a/omniwitness/omniwitness.go
+++ b/omniwitness/omniwitness.go
@@ -107,7 +107,7 @@ type FeederConfig struct {
 }
 
 // logFeeder is the de-facto interface that feeders implement.
-type logFeeder func(context.Context, config.Log, feeder.UpdateFn, *http.Client, time.Duration) error
+type logFeeder func(context.Context, config.Log, uint64, feeder.UpdateFn, *http.Client, time.Duration) (uint64, error)
 
 // Main runs the omniwitness, with the witness listening using the listener, and all
 // outbound HTTP calls using the client provided.

--- a/omniwitness/run_feeders.go
+++ b/omniwitness/run_feeders.go
@@ -1,0 +1,115 @@
+// Copyright 2025 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package omniwitness
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+
+	w_http "github.com/transparency-dev/witness/client/http"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/time/rate"
+	"k8s.io/klog/v2"
+)
+
+// RunFeedOpts is the configuration to use for RunFeeders.
+type RunFeedOpts struct {
+	// MaxWitnessQPS is the maximum number of requests to make per second to any given witness.
+	// If unset, a default of 1 QPS will be assumed.
+	MaxWitnessQPS float64
+	// HTTPClient is the HTTPClient to use, if nil uses http.DefaultClient.
+	HTTPClient *http.Client
+	// MatchLogs is an optional regex to select a submet of logs to feed.
+	MatchLogs string
+	// LogConfig provides access to log config. Required.
+	LogConfig LogConfig
+	// Witnesses is the set of witnesses to feed to. Required.
+	Witnesses []w_http.Witness
+}
+
+func RunFeeders(ctx context.Context, opts RunFeedOpts) error {
+	if opts.HTTPClient == nil {
+		opts.HTTPClient = http.DefaultClient
+	}
+	if opts.MaxWitnessQPS == 0 {
+		opts.MaxWitnessQPS = 1
+	}
+
+	eg := &errgroup.Group{}
+	// TODO: consider making this configuable if needed.
+	const maxPendingJobs = 10
+
+	// We'll have a goroutine per witness, each fed by its own work channel
+	klog.Infof("Starting %d feeder worker(s)", len(opts.Witnesses))
+	wChans := make([]chan func(w_http.Witness) error, 0, len(opts.Witnesses))
+	for _, wi := range opts.Witnesses {
+		wChan := make(chan func(w_http.Witness) error, maxPendingJobs)
+		wChans = append(wChans, wChan)
+		eg.Go(func() error {
+			for {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case f := <-wChan:
+					if err := f(wi); err != nil {
+						// Log this, but don't return the error as we want to continue
+						// executing feeder jobs until the context is done.
+						klog.Infof("[FeederWorker] Feed job failed: %v", err)
+					}
+				}
+			}
+		})
+	}
+
+	r := regexp.MustCompile(opts.MatchLogs)
+
+	// Send feeder work to workers
+	eg.Go(func() error {
+		klog.Infof("Starting feeder job creator")
+		rl := rate.NewLimiter(rate.Limit(opts.MaxWitnessQPS), 1)
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+
+			for c, err := range opts.LogConfig.Feeders(ctx) {
+				if err != nil {
+					klog.Warningf("Failed to enumerate feeders: %v", err)
+					break
+				}
+				// Skip unfeedable or unwanted logs
+				if c.Feeder == None || !r.MatchString(c.Log.Origin) {
+					continue
+				}
+				if err := rl.Wait(ctx); err != nil {
+					return fmt.Errorf("rate limit failed: %v", err)
+				}
+				// Now send jobs to the witnesses.
+				for _, wc := range wChans {
+					klog.V(1).Infof("Request to feed %s", c.Log.Origin)
+					wc <- func(w w_http.Witness) error {
+						return c.Feeder.FeedFunc()(ctx, c.Log, w.Update, opts.HTTPClient, 0 /* zero interval == run once and return */)
+					}
+				}
+			}
+		}
+	})
+
+	return eg.Wait()
+}

--- a/omniwitness/run_feeders.go
+++ b/omniwitness/run_feeders.go
@@ -67,6 +67,10 @@ func RunFeeders(ctx context.Context, opts RunFeedOpts) error {
 		eg.Go(func() error {
 			// cache of size hints for logs we've submitted to.
 			// local to this goroutine only, so no need to lock.
+			//
+			// TODO(al): this can be limited in size or disabled if the number of logs we need to
+			// witness is too large for available RAM, we'll just degrade to going through the
+			// "stale view" path with the witnesses.
 			logSizes := make(map[string]uint64)
 			for {
 				select {
@@ -118,7 +122,7 @@ func RunFeeders(ctx context.Context, opts RunFeedOpts) error {
 					wc <- wJob{
 						logID: c.Log.ID,
 						f: func(sizeHint uint64, w feeder.UpdateFn) (uint64, error) {
-							return c.Feeder.FeedFunc()(ctx, c.Log, sizeHint, w, opts.HTTPClient, 0 /* zero interval == run once and return */)
+							return c.Feeder.FeedFunc()(ctx, c.Log, sizeHint, w, opts.HTTPClient)
 						},
 					}
 				}


### PR DESCRIPTION
This PR improves the feeder implementation, making it easier to use and more friendly to feeding much larger numbers of logs without needing a correspondingly large number of goroutines.

- Extract a `RunFeeders` func, and share between `omniwitness` and `feedwitness` binaries.
- Only retry submissions to the witness if we've detected we're stale, other errors will be retried at a higher level
- Expose the current size of log according to the witnesses to higher levels, allowing that size to be cached and used as a hint for the next submission
- Don't allow one stalled witness to interfere with submissions to other witnesses.
- Use a more sensible HTTP client in `feedwitness`