### PR TITLE
[Feeder] Send the same checkpoint to all witnesses

### DIFF
--- a/cmd/feedwitness/main.go
+++ b/cmd/feedwitness/main.go
@@ -34,7 +34,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	w_http "github.com/transparency-dev/witness/client/http"
-	"github.com/transparency-dev/witness/internal/feeder"
 	"github.com/transparency-dev/witness/internal/witness"
 	"github.com/transparency-dev/witness/monitoring"
 	"github.com/transparency-dev/witness/monitoring/prometheus"
@@ -87,7 +86,7 @@ func main() {
 
 	httpClient := httpClientFromFlags()
 
-	witnesses := []feeder.UpdateFn{}
+	witnesses := []omniwitness.UpdateFn{}
 	for _, wu := range witnessURL {
 		u, err := url.Parse(wu)
 		if err != nil {

--- a/cmd/omniwitness/README.md
+++ b/cmd/omniwitness/README.md
@@ -1,4 +1,4 @@
-# The OmniWitness
+# The GCP OmniWitness
 
 The OmniWitness is a witness that will monitor all [known](../../omniwitness/logs.yaml) logs that use
 the [generic checkpoint format](https://github.com/transparency-dev/formats/tree/main/log).

--- a/internal/feeder/pixelbt/pixel_feeder.go
+++ b/internal/feeder/pixelbt/pixel_feeder.go
@@ -36,11 +36,11 @@ const (
 	tileHeight = 1
 )
 
-// NewFeedOpts returns a feeder.FeedOpts configured for PixelBT logs.
-func NewFeedOpts(l config.Log, update feeder.UpdateFn, c *http.Client) (feeder.FeedOpts, error) {
+// NewFeedSource returns a FeedSource configured for PixelBT logs.
+func NewFeedSource(l config.Log, c *http.Client) (feeder.Source, error) {
 	lURL, err := url.Parse(l.URL)
 	if err != nil {
-		return feeder.FeedOpts{}, fmt.Errorf("invalid LogURL %q: %v", l.URL, err)
+		return feeder.Source{}, fmt.Errorf("invalid LogURL %q: %v", l.URL, err)
 	}
 
 	fetchCP := func(ctx context.Context) ([]byte, error) {
@@ -76,13 +76,12 @@ func NewFeedOpts(l config.Log, update feeder.UpdateFn, c *http.Client) (feeder.F
 		return r, nil
 	}
 
-	return feeder.FeedOpts{
+	return feeder.Source{
 		LogID:           l.ID,
 		LogOrigin:       l.Origin,
 		FetchCheckpoint: fetchCP,
 		FetchProof:      fetchProof,
 		LogSigVerifier:  l.Verifier,
-		Update:          update,
 	}, nil
 }
 

--- a/internal/feeder/rekor_v1/rekor_feeder.go
+++ b/internal/feeder/rekor_v1/rekor_feeder.go
@@ -59,15 +59,15 @@ type proof struct {
 	Hashes []string `json:"hashes"`
 }
 
-// NewFeedOpts returns a populated feeder.FeedOpts struct configured for Rekor v1 logs.
-func NewFeedOpts(l config.Log, update feeder.UpdateFn, c *http.Client) (feeder.FeedOpts, error) {
+// NewFeedSource returns a populated FeedSource struct configured for Rekor v1 logs.
+func NewFeedSource(l config.Log, c *http.Client) (feeder.Source, error) {
 	lURL, err := url.Parse(l.URL)
 	if err != nil {
-		return feeder.FeedOpts{}, fmt.Errorf("invalid LogURL %q: %v", l.URL, err)
+		return feeder.Source{}, fmt.Errorf("invalid LogURL %q: %v", l.URL, err)
 	}
 	treeID := lURL.Query().Get("treeID")
 	if treeID == "" {
-		return feeder.FeedOpts{}, errors.New("configured LogURL does not contain the required treeID query parameter")
+		return feeder.Source{}, errors.New("configured LogURL does not contain the required treeID query parameter")
 	}
 
 	fetchCP := func(ctx context.Context) ([]byte, error) {
@@ -108,13 +108,12 @@ func NewFeedOpts(l config.Log, update feeder.UpdateFn, c *http.Client) (feeder.F
 		return p, nil
 	}
 
-	return feeder.FeedOpts{
+	return feeder.Source{
 		LogID:           l.ID,
 		LogOrigin:       l.Origin,
 		FetchCheckpoint: fetchCP,
 		FetchProof:      fetchProof,
 		LogSigVerifier:  l.Verifier,
-		Update:          update,
 	}, nil
 
 }

--- a/internal/feeder/serverless/serverless_feeder.go
+++ b/internal/feeder/serverless/serverless_feeder.go
@@ -31,10 +31,11 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func NewFeedOpts(l config.Log, update feeder.UpdateFn, c *http.Client) (feeder.FeedOpts, error) {
+// NewFeedSource returns a populated FeedSource configured for a serverless log.
+func NewFeedSource(l config.Log, c *http.Client) (feeder.Source, error) {
 	lURL, err := url.Parse(l.URL)
 	if err != nil {
-		return feeder.FeedOpts{}, fmt.Errorf("invalid LogURL %q: %v", l.URL, err)
+		return feeder.Source{}, fmt.Errorf("invalid LogURL %q: %v", l.URL, err)
 	}
 	f := newFetcher(c, lURL)
 	h := rfc6962.DefaultHasher
@@ -55,13 +56,12 @@ func NewFeedOpts(l config.Log, update feeder.UpdateFn, c *http.Client) (feeder.F
 		return conP, nil
 	}
 
-	return feeder.FeedOpts{
+	return feeder.Source{
 		LogID:           l.ID,
 		LogOrigin:       l.Origin,
 		FetchCheckpoint: fetchCP,
 		FetchProof:      fetchProof,
 		LogSigVerifier:  l.Verifier,
-		Update:          update,
 	}, nil
 }
 

--- a/internal/feeder/sumdb/sumdb_feeder.go
+++ b/internal/feeder/sumdb/sumdb_feeder.go
@@ -33,8 +33,8 @@ const (
 	leavesPerTile = 1 << tileHeight
 )
 
-// NewFeedOpts returns a populated feeder.NewFeedOpts configured for a sumdb log.
-func NewFeedOpts(l config.Log, update feeder.UpdateFn, c *http.Client) (feeder.FeedOpts, error) {
+// NewFeedSource returns a populated NewFeedSource configured for a sumdb log.
+func NewFeedSource(l config.Log, c *http.Client) (feeder.Source, error) {
 	sdb := client.NewSumDB(tileHeight, l.Verifier, l.URL, c)
 
 	fetchProof := func(ctx context.Context, from uint64, to log.Checkpoint) ([][]byte, error) {
@@ -68,13 +68,12 @@ func NewFeedOpts(l config.Log, update feeder.UpdateFn, c *http.Client) (feeder.F
 
 	}
 
-	return feeder.FeedOpts{
+	return feeder.Source{
 		LogID:           l.ID,
 		LogOrigin:       l.Origin,
 		FetchCheckpoint: fetchCheckpoint,
 		FetchProof:      fetchProof,
 		LogSigVerifier:  l.Verifier,
-		Update:          update,
 	}, nil
 }
 

--- a/internal/feeder/tiles/tiles_feeder.go
+++ b/internal/feeder/tiles/tiles_feeder.go
@@ -27,15 +27,15 @@ import (
 	"github.com/transparency-dev/witness/internal/feeder"
 )
 
-// NewFeedOpts returns a populated feeder.NewFeedOpts configured for a tlog-tiles log.
-func NewFeedOpts(l config.Log, update feeder.UpdateFn, c *http.Client) (feeder.FeedOpts, error) {
+// NewFeedSource returns a populated feeder.NewFeedSource configured for a tlog-tiles log.
+func NewFeedSource(l config.Log, c *http.Client) (feeder.Source, error) {
 	lURL, err := url.Parse(l.URL)
 	if err != nil {
-		return feeder.FeedOpts{}, fmt.Errorf("invalid LogURL %q: %v", l.URL, err)
+		return feeder.Source{}, fmt.Errorf("invalid LogURL %q: %v", l.URL, err)
 	}
 	f, err := client.NewHTTPFetcher(lURL, c)
 	if err != nil {
-		return feeder.FeedOpts{}, fmt.Errorf("failed to create fetcher: %v", err)
+		return feeder.Source{}, fmt.Errorf("failed to create fetcher: %v", err)
 	}
 
 	fetchProof := func(ctx context.Context, from uint64, to log.Checkpoint) ([][]byte, error) {
@@ -54,12 +54,11 @@ func NewFeedOpts(l config.Log, update feeder.UpdateFn, c *http.Client) (feeder.F
 		return conP, nil
 	}
 
-	return feeder.FeedOpts{
+	return feeder.Source{
 		LogID:           l.ID,
 		LogOrigin:       l.Origin,
 		FetchCheckpoint: f.ReadCheckpoint,
 		FetchProof:      fetchProof,
 		LogSigVerifier:  l.Verifier,
-		Update:          update,
 	}, nil
 }

--- a/omniwitness/omniwitness.go
+++ b/omniwitness/omniwitness.go
@@ -152,7 +152,7 @@ func Main(ctx context.Context, operatorConfig OperatorConfig, p LogStatePersiste
 
 	if operatorConfig.FeedInterval > 0 {
 		rOpts := RunFeedOpts{
-			Witnesses:     []feeder.UpdateFn{witness.Update},
+			Witnesses:     []UpdateFn{witness.Update},
 			HTTPClient:    httpClient,
 			MaxWitnessQPS: operatorConfig.RateLimit,
 			LogConfig:     operatorConfig.Logs,
@@ -267,18 +267,18 @@ func (f *Feeder) UnmarshalYAML(unmarshal func(any) error) (err error) {
 	return nil
 }
 
-func (f Feeder) NewOptsFunc() func(config.Log, feeder.UpdateFn, *http.Client) (feeder.FeedOpts, error) {
+func (f Feeder) NewSourceFunc() func(config.Log, *http.Client) (feeder.Source, error) {
 	switch f {
 	case Serverless:
-		return serverless.NewFeedOpts
+		return serverless.NewFeedSource
 	case SumDB:
-		return sumdb.NewFeedOpts
+		return sumdb.NewFeedSource
 	case Pixel:
-		return pixelbt.NewFeedOpts
+		return pixelbt.NewFeedSource
 	case Rekor:
-		return rekor_v1.NewFeedOpts
+		return rekor_v1.NewFeedSource
 	case Tiles:
-		return tiles.NewFeedOpts
+		return tiles.NewFeedSource
 	}
 	panic(fmt.Sprintf("unknown feeder enum: %q", f))
 }

--- a/omniwitness/run_feeders.go
+++ b/omniwitness/run_feeders.go
@@ -12,19 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO(al): We should remove the concept of feeding from Omniwitness now that we're moving to a
+// tlog-witness world, and all the stuff in here can then be moved over to `cmd/feedwitness`.
+
 package omniwitness
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
 
+	"github.com/cenkalti/backoff/v5"
+	"github.com/transparency-dev/formats/log"
 	"github.com/transparency-dev/witness/internal/feeder"
+	"github.com/transparency-dev/witness/internal/witness"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
 	"k8s.io/klog/v2"
 )
+
+// UpdateFn is the signature of a function which knows how to update a witness.
+type UpdateFn func(ctx context.Context, oldSize uint64, newCP []byte, proof [][]byte) ([]byte, uint64, error)
 
 // RunFeedOpts is the configuration to use for RunFeeders.
 type RunFeedOpts struct {
@@ -38,12 +48,12 @@ type RunFeedOpts struct {
 	// LogConfig provides access to log config. Required.
 	LogConfig LogConfig
 	// Witnesses is the set of witnesses to feed to. Required.
-	Witnesses []feeder.UpdateFn
+	Witnesses []UpdateFn
 }
 
 type wJob struct {
 	logID string
-	f     func(sizeHint uint64, f feeder.UpdateFn) (uint64, error)
+	f     func(sizeHint uint64, f UpdateFn) (uint64, error)
 }
 
 // RunFeeders continually feeds checkpoints from logs to witnesses according to the provided config.
@@ -58,7 +68,7 @@ func RunFeeders(ctx context.Context, opts RunFeedOpts) error {
 	}
 
 	eg := &errgroup.Group{}
-	// TODO: consider making this configuable if needed.
+	// TODO: consider making this configurable if needed.
 	const maxPendingJobs = 1
 
 	// We'll have a goroutine per witness, each fed by its own work channel.
@@ -120,31 +130,28 @@ func RunFeeders(ctx context.Context, opts RunFeedOpts) error {
 					return fmt.Errorf("rate limit failed: %v", err)
 				}
 
-				// Fetch a checkpoint from the log, this will be the one which we send to _all_ witnesses below.
-				opts, err := c.Feeder.NewOptsFunc()(c.Log, nil, opts.HTTPClient)
+				// Create a source for this log to be used in the feeding operation.
+				src, err := c.Feeder.NewSourceFunc()(c.Log, opts.HTTPClient)
 				if err != nil {
 					klog.Warningf("Failed to create feeder opts for %s: %v", c.Feeder.String(), err)
 					continue
 				}
-				cp, err := opts.FetchCheckpoint(ctx)
+				// First, fetch a checkpoint from the log, we're going to send this exact checkpoint to all the witnesses below.
+				// Note that we can't also pre-create a proof here because we don't know what state each of the target witnesses
+				// are in (e.g. previous updates could have failed on a subset).
+				cp, err := src.FetchCheckpoint(ctx)
 				if err != nil {
 					klog.Warningf("Failed to fetch checkpoint: %v", err)
 					continue
 				}
 
-				// Ensure all feeders use the checkpoint we just fetched.
-				opts.FetchCheckpoint = func(_ context.Context) ([]byte, error) {
-					return cp, nil
-				}
-
-				// Now send jobs to the witnesses.
+				// Now send jobs to the witness channels to update to the checkpoint above.
 				for _, wc := range wChans {
 					select {
 					case wc <- wJob{
 						logID: c.Log.ID,
-						f: func(sizeHint uint64, w feeder.UpdateFn) (uint64, error) {
-							opts.Update = w
-							return feeder.FeedOnce(ctx, sizeHint, opts)
+						f: func(sizeHint uint64, w UpdateFn) (uint64, error) {
+							return feedOnce(ctx, sizeHint, w, cp, src)
 						},
 					}:
 						klog.V(1).Infof("Request to feed %s", c.Log.Origin)
@@ -157,4 +164,68 @@ func RunFeeders(ctx context.Context, opts RunFeedOpts) error {
 	})
 
 	return eg.Wait()
+}
+
+// FeedOnce completes one feeding operation for the log and witness in the provided configuration.
+// The provided sizeHint is size of the log that the caller believes is current on the target witness.
+//
+// Returns a new hint on what the current size of the log on the target witness.
+func feedOnce(ctx context.Context, sizeHint uint64, update UpdateFn, cp []byte, src feeder.Source) (uint64, error) {
+	klog.V(2).Infof("CP to feed:\n%s", string(cp))
+
+	cpSubmit, _, _, err := log.ParseCheckpoint(cp, src.LogOrigin, src.LogSigVerifier)
+	if err != nil {
+		return sizeHint, fmt.Errorf("failed to parse checkpoint: %v", err)
+	}
+
+	newSize, err := submitToWitness(ctx, sizeHint, cp, *cpSubmit, src.FetchProof, update)
+	if err != nil {
+		return newSize, fmt.Errorf("witness submission failed: %w", err)
+	}
+	return newSize, nil
+}
+
+// submitToWitness will submit the checkpoint to the witness, retrying up to 3 times if the local checkpoint is stale.
+func submitToWitness(ctx context.Context, sizeHint uint64, cpRaw []byte, cpSubmit log.Checkpoint, fetchProof feeder.FetchProofFn, update UpdateFn) (uint64, error) {
+	// Since this func will be executed by the backoff mechanism below, we'll
+	// log any error messages directly in here before returning the error, as
+	// the backoff util doesn't seem to log them itself.
+	submitOp := func() (uint64, error) {
+		var err error
+		var conP [][]byte
+		if sizeHint > cpSubmit.Size {
+			return sizeHint, backoff.Permanent(fmt.Errorf("witness checkpoint size (%d) > submit checkpoint size (%d)", sizeHint, cpSubmit.Size))
+		}
+
+		// The witness may be configured to expect a compact-range type proof, so we need to always
+		// try to build one, even if the witness doesn't have a "latest" checkpoint for this log.
+		conP, err = fetchProof(ctx, sizeHint, cpSubmit)
+		if err != nil {
+			e := fmt.Errorf("failed to fetch consistency proof: %w", err)
+			return sizeHint, backoff.Permanent(e)
+		}
+		klog.V(2).Infof("%q: Fetched proof %d -> %d: %x", cpSubmit.Origin, sizeHint, cpSubmit.Size, conP)
+
+		_, actualSize, err := update(ctx, sizeHint, cpRaw, conP)
+		switch {
+		case errors.Is(err, witness.ErrCheckpointStale):
+			klog.V(2).Infof("%q: %d is stale, bumping to %d: %x", cpSubmit.Origin, sizeHint, cpSubmit.Size, conP)
+			sizeHint = actualSize
+			return sizeHint, backoff.RetryAfter(1)
+		case err != nil:
+			e := fmt.Errorf("%q: failed to submit checkpoint to witness: %w", cpSubmit.Origin, err)
+			return sizeHint, backoff.Permanent(e)
+		default:
+			if sizeHint == cpSubmit.Size {
+				klog.V(1).Infof("%q: Refreshed witness - @%d: %x", cpSubmit.Origin, cpSubmit.Size, cpSubmit.Hash)
+
+			} else {
+				klog.V(1).Infof("%q: Updated witness - @%d → @%d: %x", cpSubmit.Origin, sizeHint, cpSubmit.Size, cpSubmit.Hash)
+			}
+			sizeHint = cpSubmit.Size
+		}
+		return sizeHint, nil
+	}
+
+	return backoff.Retry(ctx, submitOp, backoff.WithBackOff(backoff.NewExponentialBackOff()), backoff.WithMaxTries(3))
 }


### PR DESCRIPTION
This PR updates the feeder code so that it'll send the same checkpoint to all witnesses.

This will help increase the likelihood that fed witnesses will all produce signatures for the same set of checkpoints.