### PR TITLE
Witness operates in terms of log origin only

### DIFF
--- a/cmd/gcp/omniwitness/persistence.go
+++ b/cmd/gcp/omniwitness/persistence.go
@@ -211,11 +211,13 @@ func (p *spannerPersistence) Log(ctx context.Context, logID string) (config.Log,
 	return c, true, nil
 }
 
-func (p *spannerPersistence) Latest(ctx context.Context, logID string) ([]byte, error) {
+func (p *spannerPersistence) Latest(ctx context.Context, origin string) ([]byte, error) {
+	logID := logfmt.ID(origin)
 	return getLatestCheckpoint(ctx, p.spanner.Single().ReadRow, logID)
 }
 
-func (p *spannerPersistence) Update(ctx context.Context, logID string, f func([]byte) ([]byte, error)) error {
+func (p *spannerPersistence) Update(ctx context.Context, origin string, f func([]byte) ([]byte, error)) error {
+	logID := logfmt.ID(origin)
 	_, err := p.spanner.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
 		current, err := getLatestCheckpoint(ctx, txn.ReadRow, logID)
 		if err != nil {

--- a/internal/persistence/inmemory/inmemory_test.go
+++ b/internal/persistence/inmemory/inmemory_test.go
@@ -36,13 +36,13 @@ func TestUpdateConcurrent(t *testing.T) {
 	p := NewPersistence()
 
 	g := errgroup.Group{}
-	logID := "foo"
+	origin := "foo"
 
 	for i := 0; i < 25; i++ {
 		i := i
 		g.Go(func() error {
-			return p.Update(t.Context(), logID, func(current []byte) (next []byte, err error) {
-				return []byte(fmt.Sprintf("success %d", i)), nil
+			return p.Update(t.Context(), origin, func(current []byte) (next []byte, err error) {
+				return []byte(fmt.Sprintf("%s\nsuccess %d", origin, i)), nil
 			})
 		})
 	}
@@ -51,11 +51,11 @@ func TestUpdateConcurrent(t *testing.T) {
 		t.Error(err)
 	}
 
-	cp, err := p.Latest(t.Context(), logID)
+	cp, err := p.Latest(t.Context(), origin)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.HasPrefix(string(cp), "success") {
+	if !strings.HasPrefix(string(cp), fmt.Sprintf("%s\nsuccess", origin)) {
 		t.Errorf("expected at least one success but got %s", string(cp))
 	}
 }

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -25,18 +25,14 @@ type LogStatePersistence interface {
 
 	// Latest returns the latest checkpoint.
 	// If no checkpoint exists, it must return nil.
-	Latest(ctx context.Context, logID string) ([]byte, error)
+	Latest(ctx context.Context, origin string) ([]byte, error)
 
 	// Update allows for atomically updating the currently stored (if any)
-	// checkpoint for the given logID.
+	// checkpoint for the given origin.
 	//
 	// The provided function will be passed the currently stored checkpoint
-	// for the provided log ID (or nil if no such checkpoint exists), and
+	// for the provided log origin (or nil if no such checkpoint exists), and
 	// should return the serialised form of the updated checkpoint, or an
 	// error.
-	//
-	// There is no requirement that the provided ID is present in Logs(); if
-	// the ID is not there, and this operation succeeds in committing
-	// a checkpoint, then Logs() will return the new ID afterwards.
-	Update(ctx context.Context, logID string, f func([]byte) ([]byte, error)) error
+	Update(ctx context.Context, origin string, f func([]byte) ([]byte, error)) error
 }

--- a/internal/persistence/sql/sql.go
+++ b/internal/persistence/sql/sql.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/transparency-dev/formats/log"
 	"github.com/transparency-dev/witness/internal/persistence"
 )
 
@@ -42,11 +43,13 @@ func (p *sqlLogPersistence) Init(_ context.Context) error {
 	return err
 }
 
-func (p *sqlLogPersistence) Latest(_ context.Context, logID string) ([]byte, error) {
+func (p *sqlLogPersistence) Latest(_ context.Context, origin string) ([]byte, error) {
+	logID := log.ID(origin)
 	return getLatestCheckpoint(p.db.QueryRow, logID)
 }
 
-func (p *sqlLogPersistence) Update(_ context.Context, logID string, f func([]byte) ([]byte, error)) error {
+func (p *sqlLogPersistence) Update(_ context.Context, origin string, f func([]byte) ([]byte, error)) error {
+	logID := log.ID(origin)
 	tx, err := p.db.Begin()
 	if err != nil {
 		return err

--- a/omniwitness/omniwitness.go
+++ b/omniwitness/omniwitness.go
@@ -127,11 +127,9 @@ func Main(ctx context.Context, operatorConfig OperatorConfig, p LogStatePersiste
 	}
 
 	witness, err := witness.New(ctx, witness.Opts{
-		Persistence: p,
-		Signers:     operatorConfig.WitnessKeys,
-		ConfigForLogID: func(ctx context.Context, id string) (config.Log, bool, error) {
-			return operatorConfig.Logs.Log(ctx, id)
-		},
+		Persistence:  p,
+		Signers:      operatorConfig.WitnessKeys,
+		ConfigForLog: operatorConfig.Logs.Log,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create witness: %v", err)


### PR DESCRIPTION
This PR updates the core witness API to use `origin` as a log identifier, removing `logID`.

Persistence implementations may choose to derive and use their own ID as a primary key if that makes sense for them, but it's not necessary to expose this to the witness layer.