### PR TITLE
Separate feeder and log config

### DIFF
--- a/omniwitness/http_test.go
+++ b/omniwitness/http_test.go
@@ -96,9 +96,10 @@ func TestHandler(t *testing.T) {
 	}
 	logID := log.ID(testCPOrigin)
 	logs := &staticLogConfig{
-		logs: map[string]parsedLog{
-			logID: parsedLog{Config: config.Log{Origin: testCPOrigin}},
-		}}
+		logs: map[string]config.Log{
+			logID: config.Log{Origin: testCPOrigin},
+		},
+	}
 	for _, test := range []struct {
 		name string
 		// fake witness control


### PR DESCRIPTION
This PR separates the internal representation of feeders and logs.

Currently they're both squashed together for historical/convenience reasons, but this is increasingly not helpful.