### PR TITLE
Add initial support for public witness network configuration

### DIFF
--- a/cmd/gcp/omniwitness/main.go
+++ b/cmd/gcp/omniwitness/main.go
@@ -21,16 +21,21 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/transparency-dev/witness/internal/config"
 	"github.com/transparency-dev/witness/monitoring"
 	"github.com/transparency-dev/witness/monitoring/prometheus"
 	"github.com/transparency-dev/witness/omniwitness"
 	"golang.org/x/mod/sumdb/note"
-	"gopkg.in/yaml.v3"
 	"k8s.io/klog/v2"
 )
+
+func init() {
+	flag.Var(&publicWitnessConfigs, "public_witness_config_url", "URL of a public witness network config file. May be specified multiple times to configure the union of multiple files.")
+}
 
 var (
 	addr       = flag.String("listen", ":8080", "Address to listen on")
@@ -39,8 +44,11 @@ var (
 	signerPrivateKeySecretName = flag.String("signer_private_key_secret_name", "", "Private key secret name for witnes signatures. Format: projects/{projectId}/secrets/{secretName}/versions/{secretVersion}.")
 	httpTimeout                = flag.Duration("http_timeout", 10*time.Second, "HTTP timeout for outbound requests.")
 
-	pollInterval      = flag.Duration("poll_interval", 1*time.Minute, "Time to wait between polling logs for new checkpoints. Set to 0 to disable polling logs.")
-	additionalLogYaml = flag.String("additional_logs", "", "The path to an optional addition logs YAML file. Entries in this file will be *added* to the logs configured by default")
+	pollInterval = flag.Duration("poll_interval", 1*time.Minute, "Time to wait between polling logs for new checkpoints. Set to 0 to disable polling logs.")
+
+	additionalLogYaml           = flag.String("additional_logs", "", "The path to an optional addition logs YAML file. Entries in this file will be *added* to the logs configured by default")
+	publicWitnessConfigs        multiStringFlag
+	publicWitnessConfigInterval = flag.Duration("public_witness_config_poll_interval", 1*time.Minute, "Interval between checking the public witness config for new logs to add.")
 )
 
 func main() {
@@ -90,6 +98,10 @@ func main() {
 		mustUpdateLogs(ctx, y, p)
 	}
 
+	if len(publicWitnessConfigs) > 0 {
+		go updatePublicWitnessNetworkLogs(ctx, httpClient, p)
+	}
+
 	opConfig := omniwitness.OperatorConfig{
 		WitnessKeys:     []note.Signer{signer},
 		WitnessVerifier: signer.Verifier(),
@@ -102,12 +114,59 @@ func main() {
 	}
 }
 
-func mustUpdateLogs(ctx context.Context, y []byte, p *spannerPersistence) {
-	yamlCfg := omniwitness.ConfigYAML{}
-	if err := yaml.Unmarshal(y, &yamlCfg); err != nil {
-		klog.Exitf("Failed to unmarshal yaml log config: %v", err)
+func updatePublicWitnessNetworkLogs(ctx context.Context, httpClient *http.Client, p *spannerPersistence) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(*publicWitnessConfigInterval):
+		}
+		for _, u := range publicWitnessConfigs {
+			opts := omniwitness.PublicFetchOpts{
+				Client: httpClient,
+				URL:    u,
+			}
+			logs, err := omniwitness.FetchPublicConfig(ctx, opts)
+			if err != nil {
+				klog.Warningf("Failed to fetch public witness network config from %q: %v", u, err)
+				continue
+			}
+
+			if err := p.AddLogs(ctx, logs); err != nil {
+				klog.Warningf("Failed to update list of logs: %v", err)
+				continue
+			}
+			klog.Infof("Successfully updated public witness config from %q...", u)
+		}
 	}
-	if err := p.AddLogs(ctx, yamlCfg); err != nil {
+}
+
+func mustUpdateLogs(ctx context.Context, y []byte, p *spannerPersistence) {
+	l, err := omniwitness.NewStaticLogConfig(y)
+	if err != nil {
+		klog.Exitf("Failed to parse YAML logs config: %v", err)
+	}
+	logs := []config.Log{}
+	for log, err := range l.Logs(ctx) {
+		if err != nil {
+			klog.Exitf("Error iterating over logs: %v", err)
+			logs = append(logs, log)
+		}
+	}
+	if err := p.AddLogs(ctx, logs); err != nil {
 		klog.Exitf("Failed to add default logs to Spanner: %v", err)
 	}
+}
+
+// multiStringFlag allows a flag to be specified multiple times on the command
+// line, and stores all of these values.
+type multiStringFlag []string
+
+func (ms *multiStringFlag) String() string {
+	return strings.Join(*ms, ",")
+}
+
+func (ms *multiStringFlag) Set(w string) error {
+	*ms = append(*ms, w)
+	return nil
 }

--- a/cmd/gcp/omniwitness/persistence.go
+++ b/cmd/gcp/omniwitness/persistence.go
@@ -24,7 +24,6 @@ import (
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
 	adminpb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"cloud.google.com/go/spanner/apiv1/spannerpb"
-	"github.com/transparency-dev/formats/log"
 	logfmt "github.com/transparency-dev/formats/log"
 	"github.com/transparency-dev/formats/note"
 	"github.com/transparency-dev/witness/internal/config"
@@ -161,7 +160,6 @@ func (p *spannerPersistence) Logs(ctx context.Context) iter.Seq2[config.Log, err
 					return
 				}
 			}
-			klog.Infof("Y: %s @  %+v", log.ID(c.Origin), c)
 			if !yield(c, nil) {
 				return
 			}

--- a/cmd/gcp/omniwitness/persistence.go
+++ b/cmd/gcp/omniwitness/persistence.go
@@ -23,11 +23,15 @@ import (
 	"cloud.google.com/go/spanner"
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
 	adminpb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	"cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/transparency-dev/formats/log"
 	logfmt "github.com/transparency-dev/formats/log"
 	"github.com/transparency-dev/formats/note"
 	"github.com/transparency-dev/witness/internal/config"
 	"github.com/transparency-dev/witness/omniwitness"
 	"google.golang.org/api/iterator"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
 )
 
@@ -44,6 +48,7 @@ func newSpannerPersistence(ctx context.Context, spannerURI string) (*spannerPers
 	ret := &spannerPersistence{
 		spannerURI: spannerURI,
 		spanner:    sc,
+		batchWrite: batchWrite,
 	}
 	// Need to create tables here because omniGCP may try to update logs from the embedded config.
 	if err := ret.createTablesIfNotExist(ctx); err != nil {
@@ -56,6 +61,11 @@ func newSpannerPersistence(ctx context.Context, spannerURI string) (*spannerPers
 type spannerPersistence struct {
 	spannerURI string
 	spanner    *spanner.Client
+
+	// batchWrite is a function to use for doing spanner batch writes.
+	// This only exists as an escape hatch for testing; the spanner inmemory test code doesn't
+	// support BatchWrite, so tests need to be able to replace this with _something else_.
+	batchWrite func(context.Context, *spanner.Client, []*spanner.MutationGroup) error
 }
 
 func (p *spannerPersistence) Init(ctx context.Context) error {
@@ -77,7 +87,7 @@ func (p *spannerPersistence) createTablesIfNotExist(ctx context.Context) error {
 		Database: p.spannerURI,
 		Statements: []string{
 			"CREATE TABLE IF NOT EXISTS checkpoints (logID STRING(MAX) NOT NULL, checkpoint BYTES(MAX) NOT NULL) PRIMARY KEY (logID)",
-			"CREATE TABLE IF NOT EXISTS logs (logID STRING(2048), origin STRING(2048) NOT NULL, vkey STRING(2048) NOT NULL, url STRING(2048), feeder STRING(32), disabled BOOL NOT NULL) PRIMARY KEY(logID)",
+			"CREATE TABLE IF NOT EXISTS logs (logID STRING(2048), origin STRING(2048) NOT NULL, vkey STRING(2048) NOT NULL, contact STRING(2048), qpd FLOAT64, disabled BOOL) PRIMARY KEY(logID)",
 		},
 	})
 	if err != nil {
@@ -90,24 +100,40 @@ func (p *spannerPersistence) createTablesIfNotExist(ctx context.Context) error {
 	return nil
 }
 
-func (p *spannerPersistence) AddLogs(ctx context.Context, lc omniwitness.ConfigYAML) error {
-	_, err := p.spanner.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
-		m := []*spanner.Mutation{}
-		for _, l := range lc.Logs {
-			m = append(m, spanner.InsertOrUpdate(
-				"logs",
-				[]string{"logID", "origin", "vkey", "url", "feeder"},
-				[]any{logfmt.ID(l.Origin), l.Origin, l.PublicKey, l.URL, l.Feeder.String()},
-			))
+func (p *spannerPersistence) AddLogs(ctx context.Context, lc []config.Log) error {
+	m := []*spanner.MutationGroup{}
+	for _, l := range lc {
+		m = append(m, &spanner.MutationGroup{Mutations: []*spanner.Mutation{spanner.Insert(
+			"logs",
+			[]string{"logID", "origin", "vkey", "contact"},
+			[]any{logfmt.ID(l.Origin), l.Origin, l.VKey, l.Contact},
+		)}})
+	}
+	return p.batchWrite(ctx, p.spanner, m)
+}
+
+func batchWrite(ctx context.Context, s *spanner.Client, m []*spanner.MutationGroup) error {
+	errs := []error{}
+	err := s.BatchWrite(ctx, m).Do(func(r *spannerpb.BatchWriteResponse) error {
+		switch c := codes.Code(r.Status.Code); c {
+		case codes.OK, codes.AlreadyExists:
+		// yay.
+		default:
+			errs = append(errs, status.Error(codes.Code(r.Status.Code), r.Status.Message))
 		}
-		return txn.BufferWrite(m)
+		return nil
 	})
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to inspect batch write responses: %v", err)
+
+	}
+
+	return errors.Join(errs...)
 }
 
 func (p *spannerPersistence) Logs(ctx context.Context) iter.Seq2[config.Log, error] {
 	return func(yield func(config.Log, error) bool) {
-		r := p.spanner.Single().Read(ctx, "logs", spanner.AllKeys(), []string{"origin", "vkey", "url", "disabled"})
+		r := p.spanner.Single().Read(ctx, "logs", spanner.AllKeys(), []string{"origin", "vkey", "contact", "disabled"})
 		for {
 			row, err := r.Next()
 			if err != nil {
@@ -120,8 +146,7 @@ func (p *spannerPersistence) Logs(ctx context.Context) iter.Seq2[config.Log, err
 			}
 			c := config.Log{}
 			var disabled spanner.NullBool
-			vkey := ""
-			if err := row.Columns(&c.Origin, &vkey, &c.URL, &disabled); err != nil {
+			if err := row.Columns(&c.Origin, &c.VKey, &c.Contact, &disabled); err != nil {
 				if !yield(config.Log{}, fmt.Errorf("failed to read columns: %v", err)) {
 					return
 				}
@@ -130,12 +155,13 @@ func (p *spannerPersistence) Logs(ctx context.Context) iter.Seq2[config.Log, err
 				klog.V(1).Infof("Skipping disabled log %q", c.Origin)
 				continue
 			}
-			c.Verifier, err = note.NewVerifier(vkey)
+			c.Verifier, err = note.NewVerifier(c.VKey)
 			if err != nil {
 				if !yield(config.Log{}, fmt.Errorf("failed to create verifier: %v", err)) {
 					return
 				}
 			}
+			klog.Infof("Y: %s @  %+v", log.ID(c.Origin), c)
 			if !yield(c, nil) {
 				return
 			}
@@ -186,8 +212,9 @@ func (p *spannerPersistence) Feeders(ctx context.Context) iter.Seq2[omniwitness.
 
 }
 
-func (p *spannerPersistence) Log(ctx context.Context, logID string) (config.Log, bool, error) {
-	row, err := p.spanner.Single().ReadRow(ctx, "logs", spanner.Key{logID}, []string{"origin", "vkey", "url", "disabled"})
+func (p *spannerPersistence) Log(ctx context.Context, origin string) (config.Log, bool, error) {
+	logID := logfmt.ID(origin)
+	row, err := p.spanner.Single().ReadRow(ctx, "logs", spanner.Key{logID}, []string{"origin", "vkey", "contact", "disabled"})
 	if err != nil {
 		if errors.Is(err, spanner.ErrRowNotFound) {
 			return config.Log{}, false, nil
@@ -197,7 +224,7 @@ func (p *spannerPersistence) Log(ctx context.Context, logID string) (config.Log,
 	c := config.Log{}
 	var disabled spanner.NullBool
 	vkey := ""
-	if err := row.Columns(&c.Origin, &vkey, &c.URL, &disabled); err != nil {
+	if err := row.Columns(&c.Origin, &c.VKey, &c.Contact, &disabled); err != nil {
 		return config.Log{}, false, fmt.Errorf("failed to read columns: %v", err)
 	}
 	if disabled.Bool {

--- a/internal/config/log.go
+++ b/internal/config/log.go
@@ -23,10 +23,16 @@ import (
 
 // Log describes a verifiable log.
 type Log struct {
+	// VKey is the serialised note-compliant vkey for the log.
+	VKey string
 	// Verifier is a signature verifier for log checkpoints.
 	Verifier note.Verifier
 	// Origin is the expected first line of checkpoints from the log.
 	Origin string
+	// QPD is the expected number of witness requests per day from the log.
+	QPD float64
+	// Contact is an arbitrary string with contact information for the log operator.
+	Contact string
 	// URL is the URL of the root of the log.
 	URL string
 }

--- a/omniwitness/configs.go
+++ b/omniwitness/configs.go
@@ -133,20 +133,6 @@ func (s *staticLogConfig) Merge(other *staticLogConfig) {
 	maps.Copy(s.logs, other.logs)
 }
 
-// PublicWitnessConfigLog represents an entry from one of the the public witness config files.
-type PublicWitnessConfigLog struct {
-	//VKey is the log's verifier key in note vkey format.
-	VKey string
-	// Verifier is the note Verifier corresponding to VKey.
-	Verifier note.Verifier
-	// Origin is the log's origin, if unset the origin is the Name from the vkey.
-	Origin string
-	// QPD is the maximum permitted number of witness requests the log may make each day.
-	QPD float64
-	// Contact is an optional string containing free-form contact information for the log operator.
-	Contact string
-}
-
 // PublicFetchOpts holds options to be used when fetching the public witness network config.
 type PublicFetchOpts struct {
 	// Client is the HTTP client to be used, if unset uses http.DefaultClient.
@@ -155,7 +141,7 @@ type PublicFetchOpts struct {
 	URL string
 }
 
-func FetchPublicConfig(ctx context.Context, opts PublicFetchOpts) ([]PublicWitnessConfigLog, error) {
+func FetchPublicConfig(ctx context.Context, opts PublicFetchOpts) ([]config.Log, error) {
 	if opts.Client == nil {
 		opts.Client = http.DefaultClient
 	}
@@ -180,10 +166,10 @@ func FetchPublicConfig(ctx context.Context, opts PublicFetchOpts) ([]PublicWitne
 // ParsePublicWitnessConfig implements a parser for the public witness config format.
 //
 // The format is described here: https://github.com/transparency-dev/witness-network/blob/main/log-list-format.md
-func ParsePublicWitnessConfig(r io.Reader) ([]PublicWitnessConfigLog, error) {
-	ret := []PublicWitnessConfigLog{}
+func ParsePublicWitnessConfig(r io.Reader) ([]config.Log, error) {
+	ret := []config.Log{}
 	foundHeader := false
-	var candidate *PublicWitnessConfigLog
+	var candidate *config.Log
 	scanner := bufio.NewScanner(r)
 	for l := range filteringScan(scanner) {
 		bits := strings.SplitN(l, " ", 2)
@@ -203,7 +189,7 @@ func ParsePublicWitnessConfig(r io.Reader) ([]PublicWitnessConfigLog, error) {
 			if candidate != nil {
 				ret = append(ret, *candidate)
 			}
-			candidate = &PublicWitnessConfigLog{}
+			candidate = &config.Log{}
 			if len(bits) != 2 {
 				return nil, fmt.Errorf("invalid vkey line %q", l)
 			}

--- a/omniwitness/configs.go
+++ b/omniwitness/configs.go
@@ -15,15 +15,21 @@
 package omniwitness
 
 import (
+	"bufio"
 	"context"
 	_ "embed" // embed is needed to embed files as constants
 	"fmt"
+	"io"
 	"iter"
 	"maps"
+	"net/http"
+	"strconv"
+	"strings"
 
 	logfmt "github.com/transparency-dev/formats/log"
 	f_note "github.com/transparency-dev/formats/note"
 	"github.com/transparency-dev/witness/internal/config"
+	"golang.org/x/mod/sumdb/note"
 	"gopkg.in/yaml.v3"
 )
 
@@ -63,9 +69,13 @@ func NewStaticLogConfig(yamlCfg []byte) (*staticLogConfig, error) {
 			return nil, fmt.Errorf("failed to create signature verifier: %v", err)
 		}
 		logCfg := config.Log{
+			VKey:     log.PublicKey,
 			Verifier: logV,
 			Origin:   log.Origin,
 			URL:      log.URL,
+		}
+		if log.Origin == "" {
+			log.Origin = logV.Name()
 		}
 		if log.Feeder != None {
 			f := FeederConfig{
@@ -121,4 +131,154 @@ func (s *staticLogConfig) Log(_ context.Context, id string) (config.Log, bool, e
 // Logs in the base config with the same LogID in the config to be merged will be overridden.
 func (s *staticLogConfig) Merge(other *staticLogConfig) {
 	maps.Copy(s.logs, other.logs)
+}
+
+// PublicWitnessConfigLog represents an entry from one of the the public witness config files.
+type PublicWitnessConfigLog struct {
+	//VKey is the log's verifier key in note vkey format.
+	VKey string
+	// Verifier is the note Verifier corresponding to VKey.
+	Verifier note.Verifier
+	// Origin is the log's origin, if unset the origin is the Name from the vkey.
+	Origin string
+	// QPD is the maximum permitted number of witness requests the log may make each day.
+	QPD float64
+	// Contact is an optional string containing free-form contact information for the log operator.
+	Contact string
+}
+
+// PublicFetchOpts holds options to be used when fetching the public witness network config.
+type PublicFetchOpts struct {
+	// Client is the HTTP client to be used, if unset uses http.DefaultClient.
+	Client *http.Client
+	// URL is the URL of the config file.
+	URL string
+}
+
+func FetchPublicConfig(ctx context.Context, opts PublicFetchOpts) ([]PublicWitnessConfigLog, error) {
+	if opts.Client == nil {
+		opts.Client = http.DefaultClient
+	}
+
+	req, err := http.NewRequest(http.MethodGet, opts.URL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("http.NewRequest: %w", err)
+	}
+	req = req.WithContext(ctx)
+	resp, err := opts.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http.Do: %w", err)
+	}
+	defer func() {
+		_, _ = io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	return ParsePublicWitnessConfig(resp.Body)
+}
+
+// ParsePublicWitnessConfig implements a parser for the public witness config format.
+//
+// The format is described here: https://github.com/transparency-dev/witness-network/blob/main/log-list-format.md
+func ParsePublicWitnessConfig(r io.Reader) ([]PublicWitnessConfigLog, error) {
+	ret := []PublicWitnessConfigLog{}
+	foundHeader := false
+	var candidate *PublicWitnessConfigLog
+	scanner := bufio.NewScanner(r)
+	for l := range filteringScan(scanner) {
+		bits := strings.SplitN(l, " ", 2)
+		switch keyword := strings.ToLower(strings.TrimSpace(bits[0])); keyword {
+		case "logs/v0":
+			if foundHeader {
+				return nil, fmt.Errorf("invalid config, multiple 'logs/v0' headers found")
+			}
+			foundHeader = true
+			continue
+		case "vkey":
+			// vkey introduces a new log in the config file.
+			// The argument is a note-compliant vkey string.
+			//
+			// Since vkey is always the first keyword in a new log, we can use this as a trigger to "flush" the
+			// previous log config (if any, and start a new one.
+			if candidate != nil {
+				ret = append(ret, *candidate)
+			}
+			candidate = &PublicWitnessConfigLog{}
+			if len(bits) != 2 {
+				return nil, fmt.Errorf("invalid vkey line %q", l)
+			}
+			candidate.VKey = strings.TrimSpace(bits[1])
+			v, err := note.NewVerifier(candidate.VKey)
+			if err != nil {
+				return nil, fmt.Errorf("note.NewVerifier: %v", err)
+			}
+			candidate.Verifier = v
+			candidate.Origin = v.Name()
+		case "origin":
+			// origin is an optional keyword which can be used to set a log origin which is different to the log's
+			// vkey name.
+			if candidate == nil {
+				return nil, fmt.Errorf("invalid config")
+			}
+			if len(bits) != 2 {
+				return nil, fmt.Errorf("invalid origin line %q", l)
+			}
+			candidate.Origin = strings.TrimSpace(bits[1])
+		case "qpd":
+			// qpd is the number of queries the log is permitted to send to the witness per dat.
+			// The value is interpreted as a float64.
+			if candidate == nil {
+				return nil, fmt.Errorf("invalid config")
+			}
+			if len(bits) != 2 {
+				return nil, fmt.Errorf("invalid qps line %q", l)
+			}
+			v := strings.TrimSpace(bits[1])
+			qpd, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid qps value %q: %v", v, err)
+			}
+			candidate.QPD = qpd
+		case "contact":
+			// contact is a free-form text field which contains some sort of contact information for the log operator.
+			if candidate == nil {
+				return nil, fmt.Errorf("invalid config")
+			}
+			if len(bits) != 2 {
+				return nil, fmt.Errorf("invalid contact line %q", l)
+			}
+			candidate.Contact = strings.TrimSpace(bits[1])
+		default:
+			return nil, fmt.Errorf("unexpected keyword %q", keyword)
+		}
+	}
+	// Include the final entry, if any.
+	if candidate != nil {
+		ret = append(ret, *candidate)
+		candidate = nil
+	}
+	if !foundHeader {
+		return nil, fmt.Errorf("invalid config, no 'logs/v0' header found")
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading config: %v", err)
+	}
+	return ret, nil
+}
+
+func filteringScan(s *bufio.Scanner) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for s.Scan() {
+			l := strings.TrimSpace(s.Text())
+			if l == "" {
+				continue
+			}
+			if l[0] == '#' {
+				continue
+			}
+			if !yield(l) {
+				return
+			}
+		}
+	}
 }

--- a/omniwitness/configs.go
+++ b/omniwitness/configs.go
@@ -185,7 +185,7 @@ func ParsePublicWitnessConfig(r io.Reader) ([]config.Log, error) {
 			// The argument is a note-compliant vkey string.
 			//
 			// Since vkey is always the first keyword in a new log, we can use this as a trigger to "flush" the
-			// previous log config (if any, and start a new one.
+			// previous log config, if any, and start a new one.
 			if candidate != nil {
 				ret = append(ret, *candidate)
 			}

--- a/omniwitness/configs_test.go
+++ b/omniwitness/configs_test.go
@@ -16,8 +16,10 @@ package omniwitness_test
 
 import (
 	_ "embed"
+	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/transparency-dev/witness/omniwitness"
 )
 
@@ -111,5 +113,117 @@ Logs:
 	}
 	if l := len(want); l != 0 {
 		t.Fatalf("Found %d unexpected extra logs in merged config", l)
+	}
+}
+
+func TestParsePublicWitnessConfig(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		config  string
+		want    []omniwitness.PublicWitnessConfigLog
+		wantErr bool
+	}{
+		{
+			name: "working example",
+			config: `
+					#
+					# List:      10qps-100klogs
+					# Revision:  123
+					# Generated: YYYY-MM-DD HH:MM:SS UTC
+					# Other undefined debug information.
+					#
+					logs/v0
+
+					# 1st list item -- foo's log
+					vkey sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8
+					qpd 86400
+					contact https://tlog.foo.org/contact
+
+					# 2nd list item -- log with custom origin
+					vkey sigsum.org/v1/tree/44ad38f8226ff9bd27629a41e55df727308d0a1cd8a2c31d3170048ac1dd22a1+682b49db+AQ7H4WhDEZsSA3enOROsasvC0D2CQy4sNrhBsJqVhB8l
+					origin something-not-equal-to-vkey-keyname
+					qpd 24
+					contact sysadmin (at) bar.org
+					
+					# 3rd list item - minimal log config
+					vkey tlog.andxor.it+d5e6b3d0+AU6uJ3h8tb+RRMdGjHV4KCrrHoKfIYGbhL2A46thEhKQ
+					qpd 1
+					
+					# Some trailing comments
+					`,
+			want: []omniwitness.PublicWitnessConfigLog{
+				{
+					VKey:    "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8",
+					Origin:  "sum.golang.org",
+					QPD:     86400,
+					Contact: "https://tlog.foo.org/contact",
+				}, {
+					VKey:    "sigsum.org/v1/tree/44ad38f8226ff9bd27629a41e55df727308d0a1cd8a2c31d3170048ac1dd22a1+682b49db+AQ7H4WhDEZsSA3enOROsasvC0D2CQy4sNrhBsJqVhB8l",
+					Origin:  "something-not-equal-to-vkey-keyname",
+					QPD:     24,
+					Contact: "sysadmin (at) bar.org",
+				}, {
+					VKey:   "tlog.andxor.it+d5e6b3d0+AU6uJ3h8tb+RRMdGjHV4KCrrHoKfIYGbhL2A46thEhKQ",
+					Origin: "tlog.andxor.it",
+					QPD:    1,
+				},
+			},
+		}, {
+			name:   "empty config",
+			config: "logs/v0",
+			want:   []omniwitness.PublicWitnessConfigLog{},
+		}, {
+			name: "broken: no header",
+			config: `
+					# 1st list item -- foo's log
+					vkey sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8
+					qpd 86400
+					contact https://tlog.foo.org/contact
+					`,
+			wantErr: true,
+		}, {
+			name: "broken: bad ordering, vkey not first",
+			config: `
+					logs/v0
+					# 1st list item -- foo's log
+					qpd 86400
+					vkey sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8
+					contact https://tlog.foo.org/contact
+					`,
+			wantErr: true,
+		}, {
+			name: "broken: not a vkey",
+			config: `
+					logs/v0
+					vkey BANANAS
+					# 1st list item -- foo's log
+					qpd 86400
+					contact https://tlog.foo.org/contact
+					`,
+			wantErr: true,
+		}, {
+			name: "broken: qpd not numeric",
+			config: `
+					logs/v0
+					vkey sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8
+					# 1st list item -- foo's log
+					qpd toast
+					contact https://tlog.foo.org/contact
+					`,
+			wantErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := omniwitness.ParsePublicWitnessConfig(strings.NewReader(test.config))
+			if gotErr := err != nil; gotErr != test.wantErr {
+				t.Fatalf("Got %v, want error %t", err, test.wantErr)
+			}
+			for i := range got {
+				got[i].Verifier = nil
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("Got unexpected difference: %v", diff)
+			}
+		})
 	}
 }

--- a/omniwitness/configs_test.go
+++ b/omniwitness/configs_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/transparency-dev/witness/internal/config"
 	"github.com/transparency-dev/witness/omniwitness"
 )
 
@@ -120,7 +121,7 @@ func TestParsePublicWitnessConfig(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		config  string
-		want    []omniwitness.PublicWitnessConfigLog
+		want    []config.Log
 		wantErr bool
 	}{
 		{
@@ -151,7 +152,7 @@ func TestParsePublicWitnessConfig(t *testing.T) {
 					
 					# Some trailing comments
 					`,
-			want: []omniwitness.PublicWitnessConfigLog{
+			want: []config.Log{
 				{
 					VKey:    "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8",
 					Origin:  "sum.golang.org",
@@ -171,7 +172,7 @@ func TestParsePublicWitnessConfig(t *testing.T) {
 		}, {
 			name:   "empty config",
 			config: "logs/v0",
-			want:   []omniwitness.PublicWitnessConfigLog{},
+			want:   []config.Log{},
 		}, {
 			name: "broken: no header",
 			config: `


### PR DESCRIPTION
This PR adds support for using public witness network configs to OmniGCP.

Towards #386 and #425