### PR TITLE
Simplify omniwitness

### DIFF
--- a/internal/witness/witness.go
+++ b/internal/witness/witness.go
@@ -107,9 +107,9 @@ func New(ctx context.Context, wo Opts) (*Witness, error) {
 	}, nil
 }
 
-// parse verifies the checkpoint under the appropriate key for the origin and returns
+// verifyCheckpoint verifies the checkpoint under the appropriate key for the origin and returns
 // the parsed checkpoint and the note itself.
-func (w *Witness) parse(ctx context.Context, chkptRaw []byte) (*log.Checkpoint, *note.Note, string, error) {
+func (w *Witness) verifyCheckpoint(ctx context.Context, chkptRaw []byte) (*log.Checkpoint, *note.Note, string, error) {
 	origin, _, found := strings.Cut(string(chkptRaw), "\n")
 	if !found {
 		return nil, nil, "", errors.New("invalid checkpoint")
@@ -148,7 +148,7 @@ func (w *Witness) Update(ctx context.Context, oldSize uint64, nextRaw []byte, cP
 	//
 	// SPEC: The witness MUST verify the checkpoint signature against the public key(s) it trusts for the
 	//       checkpoint origin, and it MUST ignore signatures from unknown keys.
-	next, nextNote, origin, err := w.parse(ctx, nextRaw)
+	next, nextNote, origin, err := w.verifyCheckpoint(ctx, nextRaw)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -175,7 +175,7 @@ func (w *Witness) Update(ctx context.Context, oldSize uint64, nextRaw []byte, cP
 			return signed, nil
 		}
 
-		prev, _, _, err := w.parse(ctx, prevRaw)
+		prev, _, _, err := w.verifyCheckpoint(ctx, prevRaw)
 		if err != nil {
 			retSize, retSigs = 0, nil
 			return nil, fmt.Errorf("couldn't parse stored checkpoint: %v", err)

--- a/omniwitness/configs.go
+++ b/omniwitness/configs.go
@@ -77,17 +77,17 @@ func NewStaticLogConfig(yamlCfg []byte) (*staticLogConfig, error) {
 		if log.Origin == "" {
 			log.Origin = logV.Name()
 		}
+		logID := logfmt.ID(log.Origin)
 		if log.Feeder != None {
 			f := FeederConfig{
 				Feeder: log.Feeder,
 				Log:    logCfg,
 			}
-			if oldFeeder, found := r.feeders[f.Log.Origin]; found {
-				return nil, fmt.Errorf("colliding feeder configs found for key %x: %+v and %+v", f.Log.Origin, oldFeeder, f)
+			if oldFeeder, found := r.feeders[logID]; found {
+				return nil, fmt.Errorf("colliding feeder configs found for key %x: %+v and %+v", logID, oldFeeder, f)
 			}
-			r.feeders[f.Log.Origin] = f
+			r.feeders[logID] = f
 		}
-		logID := logfmt.ID(log.Origin)
 		if oldLog, found := r.logs[logID]; found {
 			return nil, fmt.Errorf("colliding log configs found for key %x: %+v and %+v", logID, oldLog, logCfg)
 		}
@@ -121,8 +121,9 @@ func (s *staticLogConfig) Feeders(_ context.Context) iter.Seq2[FeederConfig, err
 	}
 }
 
-func (s *staticLogConfig) Log(_ context.Context, id string) (config.Log, bool, error) {
-	l, ok := s.logs[id]
+func (s *staticLogConfig) Log(_ context.Context, origin string) (config.Log, bool, error) {
+	logID := logfmt.ID(origin)
+	l, ok := s.logs[logID]
 	return l, ok, nil
 }
 

--- a/omniwitness/http_test.go
+++ b/omniwitness/http_test.go
@@ -151,7 +151,7 @@ func TestHandler(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewRequest: %v", err)
 			}
-			sc, body, ct, err := a.handleUpdate(context.Background(), testCPOrigin, 0, []byte(testCP), [][]byte{})
+			sc, body, ct, err := a.handleUpdate(context.Background(), 0, []byte(testCP), [][]byte{})
 			if err != nil {
 				t.Fatalf("handleUpdate: %v", err)
 			}


### PR DESCRIPTION
This PR simplifies the omniwitness implementation by removing some code which is no longer necessary, and renames an internal method to be clearer about what it's doing.