### PR TITLE
Use GCP base images for building

### DIFF
--- a/cmd/omniwitness_gcp/Dockerfile
+++ b/cmd/omniwitness_gcp/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine@sha256:c8c5f95d64aa79b6547f3b626eb84b16a7ce18a139e3e9ca19a8c078b85ba80d AS builder
+FROM golang:1.25-alpine@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced AS builder
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
@@ -18,7 +18,7 @@ COPY . .
 RUN go build -o bin/omniwitness ./cmd/omniwitness_gcp
 
 # Build release image
-FROM alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
+FROM us-central1-docker.pkg.dev/serverless-runtimes/google-22/runtimes/go125:go125_20260112_1_25_5_RC00@sha256:d291dbb18c0df459bda069029f70f00f66cc945ae5d70be5c2a8e5b4c3846f98
 
 COPY --from=builder /build/bin/omniwitness /bin/omniwitness
 ENTRYPOINT ["/bin/omniwitness"]


### PR DESCRIPTION
Use GCP-provided base images for building omniGCP docker image.