### PR TITLE
Check if rate limiter is initialized before use

### DIFF
--- a/omniwitness/omniwitness.go
+++ b/omniwitness/omniwitness.go
@@ -234,7 +234,7 @@ func runRestDistributors(ctx context.Context, g *errgroup.Group, httpClient *htt
 
 func rateLimit(limiter *rate.Limiter, delegate func(w http.ResponseWriter, r *http.Request)) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if !limiter.Allow() {
+		if limiter != nil && !limiter.Allow() {
             http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
             return
         }


### PR DESCRIPTION
If the `rate_limit` flag is not specified, then the limiter will not be initialized. This will cause a panic at request time.