### PR TITLE
Handle pushback without logging

### DIFF
--- a/witness/http.go
+++ b/witness/http.go
@@ -54,9 +54,6 @@ func (a *HTTPHandler) AddCheckpoint(w http.ResponseWriter, r *http.Request) {
 	sc, body, contentType, err := a.handleUpdate(r.Context(), oldSize, cp, proof)
 	if err != nil {
 		status := http.StatusInternalServerError
-		if errors.Is(err, ErrPushback) {
-			status = http.StatusTooManyRequests
-		}
 		w.WriteHeader(status)
 		return
 	}
@@ -90,6 +87,8 @@ func (a *HTTPHandler) handleUpdate(ctx context.Context, oldSize uint64, newCP []
 			return http.StatusUnprocessableEntity, nil, "", nil
 		case errors.Is(updateErr, ErrRootMismatch):
 			return http.StatusConflict, nil, "", nil
+		case errors.Is(updateErr, ErrPushback):
+			return http.StatusTooManyRequests, nil, "", nil
 		default:
 			slog.ErrorContext(ctx, "Unknown error", slog.Any("error", updateErr))
 			return http.StatusInternalServerError, nil, "", updateErr

--- a/witness/http_test.go
+++ b/witness/http_test.go
@@ -124,7 +124,12 @@ func TestHandler(t *testing.T) {
 			name:       "ErrRootMismatch",
 			witness:    &testWitness{updateErr: ErrRootMismatch},
 			wantStatus: http.StatusConflict,
+		}, {
+			name:       "ErrPushback",
+			witness:    &testWitness{updateErr: ErrPushback},
+			wantStatus: http.StatusTooManyRequests,
 		},
+
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			a := HTTPHandler{

--- a/witness/http_test.go
+++ b/witness/http_test.go
@@ -129,7 +129,6 @@ func TestHandler(t *testing.T) {
 			witness:    &testWitness{updateErr: ErrPushback},
 			wantStatus: http.StatusTooManyRequests,
 		},
-
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			a := HTTPHandler{


### PR DESCRIPTION
This avoids spammers spamming the logs
