### PR TITLE
[sqlite] Take DB path rather than opened database

### DIFF
--- a/cmd/omniwitness/monolith.go
+++ b/cmd/omniwitness/monolith.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/x509"
-	"database/sql"
 	"encoding/pem"
 	"flag"
 	"fmt"
@@ -31,16 +30,14 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	f_note "github.com/transparency-dev/formats/note"
+	"github.com/transparency-dev/witness/omniwitness"
 	"github.com/transparency-dev/witness/persistence/inmemory"
 	psql "github.com/transparency-dev/witness/persistence/sqlite"
-	"github.com/transparency-dev/witness/omniwitness"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
-
-	_ "modernc.org/sqlite" // Load drivers for sqlite3
 )
 
 func init() {
@@ -141,16 +138,10 @@ func main() {
 	if len(*dbFile) > 0 {
 		// Start up local database.
 		klog.Infof("Connecting to local DB at %q", *dbFile)
-		// Open database with some flags:
-		// - use WAL mode as this allows for read concurrency while writes are happening.
-		// - set a busy_timeout so that sqlite will queue write transactions rather than immediately return ErrBusy
-		// - set synchronous to FULL to ensure durability of commitments
-		db, err := sql.Open("sqlite", fmt.Sprintf("%s?_pragma=journal_mode(WAL)&_pragma=busy_timeout(1000)&_pragma=synchronous(FULL)", *dbFile))
-		if err != nil {
-			klog.Exitf("Failed to connect to DB: %v", err)
-		}
-		db.SetMaxOpenConns(*dbMaxConns)
-		p = psql.New(db)
+		p = psql.New(psql.Opts{
+			Path:         *dbFile,
+			MaxOpenConns: *dbMaxConns,
+		})
 		if err := p.Init(ctx); err != nil {
 			klog.Exitf("Failed to init SQL persistence: %v", err)
 		}

--- a/persistence/sqlite/sql.go
+++ b/persistence/sqlite/sql.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 	"fmt"
 	"iter"
+	"sync"
 
 	"github.com/transparency-dev/formats/log"
 	"github.com/transparency-dev/formats/note"
@@ -31,20 +32,52 @@ import (
 	sqlite3 "modernc.org/sqlite/lib"
 )
 
+// Opts represents options for the sqlite persistence layer.
+type Opts struct {
+	// Path is the path the location of the underlying SQLite database file.
+	Path string
+	// MaxOpenConns sets to maximum number of open connections to the database.
+	MaxOpenConns int
+}
+
 // New returns a persistence object that is backed by the provided database.
-func New(db *sql.DB) *Persistence {
+func New(opts Opts) *Persistence {
 	return &Persistence{
-		db: db,
+		opts: opts,
+		dbInit: &sync.Mutex{},
 	}
 }
 
 // Persistence is an implementation of witness.Persistence which knows how to use an sqlite
 // database to safely store witness state.
 type Persistence struct {
+	opts Opts
+
+	dbInit *sync.Mutex
 	db *sql.DB
 }
 
 func (p *Persistence) Init(ctx context.Context) error {
+	p.dbInit.Lock()
+	defer p.dbInit.Unlock()
+
+	if p.db != nil {
+		return nil
+	}
+
+	// Open database with some flags:
+	// - use WAL mode as this allows for read concurrency while writes are happening.
+	// - set a busy_timeout so that sqlite will queue write transactions rather than immediately return ErrBusy
+	// - set synchronous to FULL to ensure durability of commitments
+	db, err := sql.Open("sqlite", fmt.Sprintf("%s?_pragma=journal_mode(WAL)&_pragma=busy_timeout(1000)&_pragma=synchronous(FULL)", p.opts.Path))
+	if err != nil {
+		return fmt.Errorf("failed to connect to DB: %v", err)
+	}
+	if p.opts.MaxOpenConns != 0 {
+		db.SetMaxOpenConns(p.opts.MaxOpenConns)
+	}
+	p.db = db
+
 	for _, ddl := range []string{
 		"CREATE TABLE IF NOT EXISTS chkpts (logID BLOB PRIMARY KEY, chkpt BLOB)",
 		"CREATE TABLE IF NOT EXISTS logs (logID BLOB PRIMARY KEY, origin STRING NOT NULL, vkey STRING NOT NULL, contact STRING, qpd FLOAT64, disabled BOOL)",

--- a/persistence/sqlite/sql_test.go
+++ b/persistence/sqlite/sql_test.go
@@ -16,7 +16,6 @@ package sqlite
 
 import (
 	"context"
-	"database/sql"
 	"encoding/hex"
 	"testing"
 	"time"
@@ -27,34 +26,26 @@ import (
 	"github.com/transparency-dev/witness/witness"
 	ptest "github.com/transparency-dev/witness/persistence/testonly"
 	"golang.org/x/mod/sumdb/note"
-	_ "modernc.org/sqlite" // Load drivers for sqlite3
 )
 
 func TestUpdate(t *testing.T) {
 	ptest.TestUpdate(t, func() (*Persistence, func() error) {
-		db, close := mustCreateDB(t)
-		return New(db), close
+		p := New(Opts{Path: ":memory:", MaxOpenConns: 1})
+		return p, func() error { 
+			if p.db != nil {
+				return p.db.Close()
+			}
+			return nil
+		}
 	})
 }
 
-func mustCreateDB(t *testing.T) (*sql.DB, func() error) {
-	t.Helper()
-	db, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatalf("failed to open temporary DB: %v", err)
-	}
-	db.SetMaxOpenConns(1)
-	return db, db.Close
-}
-
 func TestLogConfig(t *testing.T) {
-	db, cleanup := mustCreateDB(t)
-	defer func() { _ = cleanup() }()
-
-	p := New(db)
+	p := New(Opts{Path: ":memory:", MaxOpenConns: 1})
 	if err := p.Init(t.Context()); err != nil {
 		t.Fatalf("Init(): %v", err)
 	}
+	defer func() { _ = p.db.Close() }()
 
 	vkey := "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8"
 	logs := []omniwitness.Log{
@@ -118,19 +109,17 @@ func TestLogConfig(t *testing.T) {
 }
 
 func TestDisabledLogs(t *testing.T) {
-	db, cleanup := mustCreateDB(t)
-	defer func() { _ = cleanup() }()
-
-	p := New(db)
+	p := New(Opts{Path: ":memory:", MaxOpenConns: 1})
 	if err := p.Init(t.Context()); err != nil {
 		t.Fatalf("Init(): %v", err)
 	}
+	defer func() { _ = p.db.Close() }()
 
 	vkey := "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8"
 
 	// Test disabled logs
 	// Manually insert a disabled log
-	if _, err := db.ExecContext(t.Context(), "INSERT INTO logs (logID, origin, vkey, contact, disabled) VALUES (?, ?, ?, ?, ?)", log.ID("log3"), "log3", vkey, "", true); err != nil {
+	if _, err := p.db.ExecContext(t.Context(), "INSERT INTO logs (logID, origin, vkey, contact, disabled) VALUES (?, ?, ?, ?, ?)", log.ID("log3"), "log3", vkey, "", true); err != nil {
 		t.Fatalf("failed to insert disabled log: %v", err)
 	}
 
@@ -156,13 +145,11 @@ func TestDisabledLogs(t *testing.T) {
 }
 
 func TestDeadlock(t *testing.T) {
-	db, cleanup := mustCreateDB(t) // MaxOpenConns(1)
-	defer func() { _ = cleanup() }()
-
-	p := New(db)
+	p := New(Opts{Path: ":memory:", MaxOpenConns: 1})
 	if err := p.Init(t.Context()); err != nil {
 		t.Fatalf("Init(): %v", err)
 	}
+	defer func() { _ = p.db.Close() }()
 
 	mPK := "monkeys+db4d9f7e+AULaJMvTtDLHPUcUrjdDad9vDlh/PTfC2VV60JUtCfWT"
 	wSK := "PRIVATE+KEY+witness+f13a86db+AaLa/dfyBhyo/m0Z7WCi98ENVZWtrP8pxgRNrx7tIWiA"


### PR DESCRIPTION
This PR makes the sqlite persistence c'tor use a path (via opts struct) to an sqlite DB file, rather than taking an opened DB.

The sqlite pragma options are important for the durability and correctness of the witness DB, so we shouldn't rely on the caller having correctly added them when opening a DB.