### PR TITLE
Follow c2sp.org/tlog-witness#280 changes

### DIFF
--- a/witness/http.go
+++ b/witness/http.go
@@ -86,7 +86,7 @@ func (a *HTTPHandler) handleUpdate(ctx context.Context, oldSize uint64, newCP []
 		case errors.Is(updateErr, ErrInvalidProof):
 			return http.StatusUnprocessableEntity, nil, "", nil
 		case errors.Is(updateErr, ErrRootMismatch):
-			return http.StatusConflict, nil, "", nil
+			return http.StatusUnprocessableEntity, nil, "", nil
 		case errors.Is(updateErr, ErrPushback):
 			return http.StatusTooManyRequests, nil, "", nil
 		default:

--- a/witness/http_test.go
+++ b/witness/http_test.go
@@ -123,7 +123,7 @@ func TestHandler(t *testing.T) {
 		}, {
 			name:       "ErrRootMismatch",
 			witness:    &testWitness{updateErr: ErrRootMismatch},
-			wantStatus: http.StatusConflict,
+			wantStatus: http.StatusUnprocessableEntity,
 		}, {
 			name:       "ErrPushback",
 			witness:    &testWitness{updateErr: ErrPushback},

--- a/witness/witness.go
+++ b/witness/witness.go
@@ -155,6 +155,13 @@ func (w *Witness) Update(ctx context.Context, oldSize uint64, nextRaw []byte, cP
 		return nil, 0, err
 	}
 
+	// SPEC: A checkpoint of size zero MUST have the root hash of the empty tree, which
+	//		RFC 6962, Section 2.1 defines as the hash of the empty string. Otherwise,
+	//		the witness MUST respond with a "422 Unprocessable Entity" HTTP status code.
+	if next.Size == 0 && !bytes.Equal(next.Hash, rfc6962.DefaultHasher.EmptyRoot()) {
+		return nil, 0, ErrRootMismatch
+	}
+
 	counterUpdateAttempt.Add(ctx, 1, metric.WithAttributes(originKey.String(origin)))
 
 	var retSigs []byte

--- a/witness/witness_test.go
+++ b/witness/witness_test.go
@@ -221,6 +221,20 @@ func TestUpdate(t *testing.T) {
 			pf:      consProof,
 			isGood:  true,
 		}, {
+			desc:    "valid zero size hash",
+			origin:  "monkeys",
+			initC:   mustCreateCheckpoint(t, mSK, "monkeys", 0, rfc6962.DefaultHasher.EmptyRoot()),
+			oldSize: 0,
+			newC:   mustCreateCheckpoint(t, mSK, "monkeys", 0, rfc6962.DefaultHasher.EmptyRoot()),
+			isGood:  true,
+	}, {
+			desc:    "invalid zero size hash",
+			origin:  "monkeys",
+			initC:   mustCreateCheckpoint(t, mSK, "monkeys", 0, rfc6962.DefaultHasher.EmptyRoot()),
+			oldSize: 0,
+			newC:   mustCreateCheckpoint(t, mSK, "monkeys", 0, dh("e35b268c1522014ef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),
+			wantError: ErrRootMismatch,
+		}, {
 			desc:      "oldSize doesn't match current state",
 			origin:    "monkeys",
 			initC:     mustCreateCheckpoint(t, mSK, "monkeys", 5, dh("e35b268c1522014ef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),


### PR DESCRIPTION
This PR updates the `witness` package with the recent changes in https://github.com/C2SP/C2SP/pull/280.

Now, root hashes for zero-size checkpoints must be as specified in RFC6962, and 422 is used for root mismatch as well as invalid proof (both are just special cases of an inconsistent request).