### PR TITLE
Fix incorrect error when log unknown, and add a bunch of tests

### DIFF
--- a/persistence/spanner/persistence.go
+++ b/persistence/spanner/persistence.go
@@ -70,6 +70,7 @@ type Persistence struct {
 	batchWrite func(context.Context, *spanner.Client, []*spanner.MutationGroup) error
 }
 
+// Init initialises the persistence layer.
 func (p *Persistence) Init(ctx context.Context) error {
 	return nil
 }
@@ -102,6 +103,7 @@ func (p *Persistence) createTablesIfNotExist(ctx context.Context) error {
 	return nil
 }
 
+// AddLogs adds the provided log configs to the database.
 func (p *Persistence) AddLogs(ctx context.Context, lc []config.Log) error {
 	m := []*spanner.MutationGroup{}
 	for _, l := range lc {
@@ -143,6 +145,9 @@ func batchWrite(ctx context.Context, s *spanner.Client, m []*spanner.MutationGro
 	return errors.Join(errs...)
 }
 
+// Logs returns an iterator over the set of known and enabled log configs.
+// Disabled logs will be skipped.
+// An error is returned only if there was an error while attempting to read from the storage.
 func (p *Persistence) Logs(ctx context.Context) iter.Seq2[config.Log, error] {
 	return func(yield func(config.Log, error) bool) {
 		r := p.spanner.Single().Read(ctx, "logs", spanner.AllKeys(), []string{"origin", "vkey", "contact", "disabled"})
@@ -182,6 +187,9 @@ func (p *Persistence) Logs(ctx context.Context) iter.Seq2[config.Log, error] {
 	}
 }
 
+// Log returns the configuration info for the provided log, if it exists.
+// Returns the config and true if found, false and no error if not found.
+// An error is returned only if there was an error while attempting to read from the storage.
 func (p *Persistence) Log(ctx context.Context, origin string) (config.Log, bool, error) {
 	logID := logfmt.ID(origin)
 	row, err := p.spanner.Single().ReadRow(ctx, "logs", spanner.Key{logID}, []string{"origin", "vkey", "contact", "disabled"})
@@ -209,11 +217,13 @@ func (p *Persistence) Log(ctx context.Context, origin string) (config.Log, bool,
 	return c, true, nil
 }
 
+// Latest returns the latest checkpoint for the given log, if it exists, and nil otherwise.
 func (p *Persistence) Latest(ctx context.Context, origin string) ([]byte, error) {
 	logID := logfmt.ID(origin)
 	return getLatestCheckpoint(ctx, p.spanner.Single().ReadRow, logID)
 }
 
+// Update attempts to atomically update the latest checkpoint for the given log.
 func (p *Persistence) Update(ctx context.Context, origin string, f func([]byte) ([]byte, error)) error {
 	logID := logfmt.ID(origin)
 	_, err := p.spanner.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {

--- a/persistence/sqlite/sql.go
+++ b/persistence/sqlite/sql.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/transparency-dev/formats/log"
 	"github.com/transparency-dev/formats/note"
-	"github.com/transparency-dev/witness/witness"
 	"github.com/transparency-dev/witness/config"
+	"github.com/transparency-dev/witness/witness"
 	"k8s.io/klog/v2"
 
 	"modernc.org/sqlite"
@@ -69,6 +69,7 @@ type Persistence struct {
 	db *sql.DB
 }
 
+// Init initialises the persistence layer.
 func (p *Persistence) Init(ctx context.Context) error {
 	return nil
 }
@@ -85,6 +86,7 @@ func (p *Persistence) createTablesIfNotExist(ctx context.Context) error {
 	return nil
 }
 
+// AddLogs adds the provided log configs to the database.
 func (p *Persistence) AddLogs(ctx context.Context, lc []config.Log) error {
 	for _, l := range lc {
 		// Note that it's a deliberate choice here to use Insert so as to guarantee that we will not
@@ -100,6 +102,9 @@ func (p *Persistence) AddLogs(ctx context.Context, lc []config.Log) error {
 	return nil
 }
 
+// Logs returns an iterator over the set of known and enabled log configs.
+// Disabled logs will be skipped.
+// An error is returned only if there was an error while attempting to read from the storage.
 func (p *Persistence) Logs(ctx context.Context) iter.Seq2[config.Log, error] {
 	return func(yield func(config.Log, error) bool) {
 		rows, err := p.db.QueryContext(ctx, "SELECT origin, vkey, contact, disabled FROM logs")
@@ -133,9 +138,17 @@ func (p *Persistence) Logs(ctx context.Context) iter.Seq2[config.Log, error] {
 				return
 			}
 		}
+		if err := rows.Err(); err != nil {
+			if !yield(config.Log{}, fmt.Errorf("rows.Err(): %v", err)) {
+				return
+			}
+		}
 	}
 }
 
+// Log returns the configuration info for the provided log, if it exists.
+// Returns the config and true if found, false and no error if not found.
+// An error is returned only if there was an error while attempting to read from the storage.
 func (p *Persistence) Log(ctx context.Context, origin string) (config.Log, bool, error) {
 	logID := log.ID(origin)
 	row := p.db.QueryRowContext(ctx, "SELECT origin, vkey, contact, disabled FROM logs WHERE logID = ?", logID)
@@ -145,6 +158,9 @@ func (p *Persistence) Log(ctx context.Context, origin string) (config.Log, bool,
 	c := config.Log{}
 	disabled := false
 	if err := row.Scan(&c.Origin, &c.VKey, &c.Contact, &disabled); err != nil {
+		if err == sql.ErrNoRows {
+			return config.Log{}, false, nil
+		}
 		return config.Log{}, false, fmt.Errorf("failed to scan columns: %v", err)
 	}
 	if disabled {
@@ -159,6 +175,7 @@ func (p *Persistence) Log(ctx context.Context, origin string) (config.Log, bool,
 	return c, true, nil
 }
 
+// Latest returns the latest checkpoint for the given log, if it exists, and nil otherwise.
 func (p *Persistence) Latest(ctx context.Context, origin string) ([]byte, error) {
 	logID := log.ID(origin)
 	return getLatestCheckpoint(ctx, p.db.QueryRowContext, logID)
@@ -167,15 +184,16 @@ func (p *Persistence) Latest(ctx context.Context, origin string) ([]byte, error)
 // handleBusyErr will return a witness.ErrPushback if the provided error code is SQLITE_BUSY,
 // or return the provided error otherwise.
 func handleBusyErr(err error) error {
-	if sqliteErr, ok := err.(*sqlite.Error); ok && 
-	  (sqliteErr.Code() == sqlite3.SQLITE_BUSY ||
-	   sqliteErr.Code() == sqlite3.SQLITE_BUSY_SNAPSHOT ||
-	   sqliteErr.Code() == sqlite3.SQLITE_LOCKED) {
+	if sqliteErr, ok := err.(*sqlite.Error); ok &&
+		(sqliteErr.Code() == sqlite3.SQLITE_BUSY ||
+			sqliteErr.Code() == sqlite3.SQLITE_BUSY_SNAPSHOT ||
+			sqliteErr.Code() == sqlite3.SQLITE_LOCKED) {
 		return witness.ErrPushback
 	}
 	return err
 }
 
+// Update attempts to atomically update the latest checkpoint for the given log.
 func (p *Persistence) Update(ctx context.Context, origin string, f func([]byte) ([]byte, error)) error {
 	logID := log.ID(origin)
 	tx, err := p.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})

--- a/persistence/sqlite/sql_test.go
+++ b/persistence/sqlite/sql_test.go
@@ -15,6 +15,7 @@
 package sqlite
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"testing"
@@ -23,8 +24,8 @@ import (
 	"github.com/transparency-dev/formats/log"
 	f_note "github.com/transparency-dev/formats/note"
 	"github.com/transparency-dev/witness/config"
-	"github.com/transparency-dev/witness/witness"
 	ptest "github.com/transparency-dev/witness/persistence/testonly"
+	"github.com/transparency-dev/witness/witness"
 	"golang.org/x/mod/sumdb/note"
 )
 
@@ -223,5 +224,141 @@ func TestDeadlock(t *testing.T) {
 	_, _, err = w.Update(ctx, 5, mNext, consProof)
 	if err != nil {
 		t.Fatalf("Second Update failed (expected success with fix): %v", err)
+	}
+}
+
+func TestLatest(t *testing.T) {
+	for _, test := range []struct {
+		desc   string
+		setup  func(ctx context.Context, t *testing.T, p *Persistence)
+		origin string
+		wantCp []byte
+	}{
+		{
+			desc:   "no checkpoint exists (empty DB)",
+			origin: "log1",
+			wantCp: nil,
+		},
+		{
+			desc: "no checkpoint exists for requested log when another log has checkpoint",
+			setup: func(ctx context.Context, t *testing.T, p *Persistence) {
+				if err := p.Update(ctx, "other_log", func(current []byte) ([]byte, error) {
+					return []byte("other_checkpoint"), nil
+				}); err != nil {
+					t.Fatalf("Update(other_log): %v", err)
+				}
+			},
+			origin: "log1",
+			wantCp: nil,
+		},
+		{
+			desc: "checkpoint exists for requested log",
+			setup: func(ctx context.Context, t *testing.T, p *Persistence) {
+				if err := p.Update(ctx, "log1", func(current []byte) ([]byte, error) {
+					return []byte("checkpoint_content"), nil
+				}); err != nil {
+					t.Fatalf("Update(log1): %v", err)
+				}
+			},
+			origin: "log1",
+			wantCp: []byte("checkpoint_content"),
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			p, shutdown, err := New(t.Context(), Opts{Path: ":memory:", MaxOpenConns: 1})
+			if err != nil {
+				t.Fatalf("New(): %v", err)
+			}
+			if err := p.Init(t.Context()); err != nil {
+				t.Fatalf("Init(): %v", err)
+			}
+			defer func() { _ = shutdown() }()
+
+			if test.setup != nil {
+				test.setup(t.Context(), t, p)
+			}
+
+			got, err := p.Latest(t.Context(), test.origin)
+			if err != nil {
+				t.Fatalf("Latest(%q): %v", test.origin, err)
+			}
+			if !bytes.Equal(got, test.wantCp) {
+				t.Errorf("Latest(%q) = %q, want %q", test.origin, got, test.wantCp)
+			}
+		})
+	}
+}
+
+func TestLog(t *testing.T) {
+	vkey := "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8"
+	for _, test := range []struct {
+		desc       string
+		setup      func(ctx context.Context, t *testing.T, p *Persistence)
+		origin     string
+		wantFound  bool
+		wantOrigin string
+	}{
+		{
+			desc:      "log does not exist on empty DB",
+			origin:    "nonexistent",
+			wantFound: false,
+		},
+		{
+			desc: "log does not exist when other logs exist",
+			setup: func(ctx context.Context, t *testing.T, p *Persistence) {
+				if err := p.AddLogs(ctx, []config.Log{{Origin: "log1", VKey: vkey}}); err != nil {
+					t.Fatalf("AddLogs: %v", err)
+				}
+			},
+			origin:    "nonexistent",
+			wantFound: false,
+		},
+		{
+			desc: "log exists and is enabled",
+			setup: func(ctx context.Context, t *testing.T, p *Persistence) {
+				if err := p.AddLogs(ctx, []config.Log{{Origin: "log1", VKey: vkey}}); err != nil {
+					t.Fatalf("AddLogs: %v", err)
+				}
+			},
+			origin:     "log1",
+			wantFound:  true,
+			wantOrigin: "log1",
+		},
+		{
+			desc: "log exists but is disabled",
+			setup: func(ctx context.Context, t *testing.T, p *Persistence) {
+				if _, err := p.db.ExecContext(ctx, "INSERT INTO logs (logID, origin, vkey, contact, disabled) VALUES (?, ?, ?, ?, ?)", log.ID("disabled_log"), "disabled_log", vkey, "", true); err != nil {
+					t.Fatalf("insert disabled log: %v", err)
+				}
+			},
+			origin:    "disabled_log",
+			wantFound: false,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			p, shutdown, err := New(t.Context(), Opts{Path: ":memory:", MaxOpenConns: 1})
+			if err != nil {
+				t.Fatalf("New(): %v", err)
+			}
+			if err := p.Init(t.Context()); err != nil {
+				t.Fatalf("Init(): %v", err)
+			}
+			defer func() { _ = shutdown() }()
+
+			if test.setup != nil {
+				test.setup(t.Context(), t, p)
+			}
+
+			l, found, err := p.Log(t.Context(), test.origin)
+			if err != nil {
+				t.Fatalf("Log(%q) unexpected error: %v", test.origin, err)
+			}
+			if found != test.wantFound {
+				t.Errorf("Log(%q) found = %v, want %v", test.origin, found, test.wantFound)
+			}
+			if test.wantFound && l.Origin != test.wantOrigin {
+				t.Errorf("Log(%q) origin = %q, want %q", test.origin, l.Origin, test.wantOrigin)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR fixes a couple of bugs in the sqlite storage implementation where:
 - it incorrectly returns an error when config for an unknown log is requested.
 - it failed to check rows.Err after iterating