### PR TITLE
Harden the Docker image

### DIFF
--- a/cmd/omniwitness/Dockerfile
+++ b/cmd/omniwitness/Dockerfile
@@ -1,26 +1,35 @@
 FROM golang:1.27-alpine@sha256:cf6fca6641884b8433441b2b0652976f975e1d0fdd26d177eaaf8596087f3125 AS builder
-RUN apk add --no-cache gcc musl-dev
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
-ENV GO111MODULE=on
+ENV CGO_ENABLED=0
 
 # Move to working directory /build
 WORKDIR /build
 
 # Copy and download dependency using go mod
-COPY go.mod .
-COPY go.sum .
+COPY go.mod go.sum .
 RUN go mod download
 
 # Copy the code into the container
 COPY . .
 
 # Build the application
-RUN go build -o bin/omniwitness ./cmd/omniwitness
+RUN go build -trimpath -ldflags="-s -w" -o bin/omniwitness ./cmd/omniwitness
 
-# Build release image
-FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+# Created here: the release image has no shell to mkdir with.
+RUN mkdir -p /build/data
 
+# Build release image.
+# No shell, no package manager, uid/gid 65532, ships CA certificates.
+FROM gcr.io/distroless/static-debian13:nonroot@sha256:1c2c046bc09ed40fad370b599a0b1ae7987f55b01e247cf27a7c27cd97e5bbc7
+
+COPY --from=builder --chown=65532:65532 /build/data /data
 COPY --from=builder /build/bin/omniwitness /bin/omniwitness
+
+USER 65532:65532
+
+# Defaults of --listen and --metrics_listen; both >1024.
+EXPOSE 8080 8081
+
 ENTRYPOINT ["/bin/omniwitness"]

--- a/cmd/omniwitness/README.md
+++ b/cmd/omniwitness/README.md
@@ -14,6 +14,9 @@ a single executable that bundles all of the components. Instructions for deployi
 1. Create a `.env` file in this new directory, populated as described in [configuration](#configuration)
 1. From that directory, run `docker compose up -d`
 
+The image is hardened. It runs as uid 65532, read-only, with no capabilities.
+Docker gives the `data` volume the right ownership, so host-mounted paths need `chown 65532`.
+
 ### .env File
 
 The `.env` file required for the Docker service is a key-value format with this template:

--- a/cmd/omniwitness/docker-compose.yaml
+++ b/cmd/omniwitness/docker-compose.yaml
@@ -2,21 +2,26 @@ services:
   witness:
     image: gcr.io/trillian-opensource-ci/omniwitness:${WITNESS_VERSION}
     volumes:
-        - type: volume
-          source: data
-          target: /data
-          volume:
-            nocopy: true
-        - type: bind
-          source: ${WITNESS_PRIVATE_KEY_PATH}
-          target: /private_key
-          read_only: true
+      - type: volume
+        source: data
+        target: /data
+      - type: bind
+        source: ${WITNESS_PRIVATE_KEY_PATH}
+        target: /private_key
+        read_only: true
     command:
       - "--listen=:8100"
       - "--db_file=/data/witness.sqlite"
       - "--private_key_path=/private_key"
       - "--logtostderr"
       - "--v=2"
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=64m
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     restart: always
     ports:
       - "8100:8100"


### PR DESCRIPTION
This PR hardens the `omniwitness` Docker image:

* `distroless/static:nonroot` instead of root-on-Alpine
* static build now that #558 has removed the CGO dep
* read-only rootfs and dropped capabilities in `docker-compose.yaml`.